### PR TITLE
Add support for additional Should operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Public commands:
   - `Convert-PesterSyntax`
+- Add support for additional Should operators:
+  - `Should-BeGreaterThan`
+  - `Should-BeGreaterOrEqual`
+  - `Should-BeLessThan`
+  - `Should-BeLessOrEqual`.
 
 ### Fixed
 

--- a/source/Private/Convert-ShouldBeGreaterOrEqual.ps1
+++ b/source/Private/Convert-ShouldBeGreaterOrEqual.ps1
@@ -1,0 +1,202 @@
+<#
+    .SYNOPSIS
+        Converts a command `Should -BeGreaterOrEqual` to the specified Pester syntax.
+
+    .DESCRIPTION
+        The Convert-ShouldBeGreaterOrEqual function is used to convert a command `Should -BeGreaterOrEqual` to
+        the specified Pester syntax.
+
+    .PARAMETER CommandAst
+        The CommandAst object representing the command to be converted.
+
+    .PARAMETER Pester6
+        Specifies that the command should be converted to Pester version 6 syntax.
+
+    .PARAMETER UseNamedParameters
+        Specifies whether to use named parameters in the converted syntax.
+
+    .PARAMETER UsePositionalParameters
+        Specifies whether to use positional parameters in the converted syntax,
+        where supported.
+
+    .EXAMPLE
+        $commandAst = [System.Management.Automation.Language.Parser]::ParseInput('Should -BeGreaterOrEqual 2')
+        Convert-ShouldBeGreaterOrEqual -CommandAst $commandAst -Pester6
+
+        This example converts the `Should -BeGreaterOrEqual 2` command to Pester 6 syntax.
+
+    .NOTES
+        Pester 5 Syntax:
+            Should -BeGreaterOrEqual [[-ActualValue] <Object>] [[-ExpectedValue] <Object>] [[-Because] <string>] [-Not]
+
+            Positional parameters:
+                Position 1: ExpectedValue
+                Position 2: Because
+                Position 3: ActualValue
+
+        Pester 6 Syntax:
+            Should-BeGreaterOrEqualOrEqual [[-Actual] <Object>] [-Expected] <Object> [-Because <String>]
+            Should-BeLessThanOrEqual [[-Actual] <Object>] [-Expected] <Object> [-Because <String>]
+
+            Positional parameters:
+                Position 1: Expected
+                Position 2: Actual
+#>
+function Convert-ShouldBeGreaterOrEqual
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.CommandAst]
+        $CommandAst,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Pester6')]
+        [System.Management.Automation.SwitchParameter]
+        $Pester6,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UseNamedParameters,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UsePositionalParameters
+    )
+
+    $assertBoundParameterParameters = @{
+        BoundParameterList     = $PSBoundParameters
+        MutuallyExclusiveList1 = @('UseNamedParameters')
+        MutuallyExclusiveList2 = @('UsePositionalParameters')
+    }
+
+    Assert-BoundParameter @assertBoundParameterParameters
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ParsingCommandAst -f $CommandAst.Extent.Text)
+
+    # Determine if the command is negated
+    $isNegated = Test-PesterCommandNegated -CommandAst $CommandAst
+
+    $sourceSyntaxVersion = Get-PesterCommandSyntaxVersion -CommandAst $CommandAst
+
+    # Parse the command elements and convert them to Pester 6 syntax
+    if ($PSCmdlet.ParameterSetName -eq 'Pester6')
+    {
+        Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertingFromTo -f $sourceSyntaxVersion, '6')
+
+        # Add the correct Pester command based on negation
+        if ($isNegated)
+        {
+            $newExtentText = 'Should-BeLessThanOrEqual'
+        }
+        else
+        {
+            $newExtentText = 'Should-BeGreaterThanOrEqual'
+        }
+
+        $getPesterCommandParameterParameters = @{
+            CommandAst          = $CommandAst
+            CommandName         = 'Should'
+            IgnoreParameter     = @(
+                'BeGreaterOrEqual'
+                'GE'
+                'Not'
+            )
+            PositionalParameter = @(
+                'ExpectedValue'
+                'Because'
+                'ActualValue'
+            )
+        }
+
+        $commandParameters = Get-PesterCommandParameter @getPesterCommandParameterParameters
+
+        # Parameter 'Because' is only supported as named parameter in Pester 6 syntax.
+        if ($commandParameters.Because)
+        {
+            $commandParameters.Because.Positional = $false
+        }
+
+        # Determine if named or positional parameters should be forcibly used
+        if ($UseNamedParameters.IsPresent)
+        {
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+        }
+        elseif ($UsePositionalParameters.IsPresent)
+        {
+            # First set all to named parameters
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+
+            <#
+                If a previous positional parameter is missing then the ones behind
+                it cannot be set to positional.
+            #>
+            if ($commandParameters.ExpectedValue)
+            {
+                $commandParameters.ExpectedValue.Positional = $true
+
+                if ($commandParameters.ActualValue)
+                {
+                    $commandParameters.ActualValue.Positional = $true
+                }
+            }
+        }
+
+        $newExtentText += $commandParameters.ExpectedValue.Positional ? (' {0}' -f $commandParameters.ExpectedValue.ExtentText) : ''
+        $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
+
+        # Holds the new parameter names so they can be added in alphabetical order.
+        $parameterNames = @()
+
+        foreach ($currentParameter in $commandParameters.Keys)
+        {
+            if ($commandParameters.$currentParameter.Positional -eq $true)
+            {
+                continue
+            }
+
+            switch ($currentParameter)
+            {
+                'ActualValue'
+                {
+                    $parameterNames += @{
+                        Actual = 'ActualValue'
+                    }
+
+                    break
+                }
+
+                'ExpectedValue'
+                {
+                    $parameterNames += @{
+                        Expected = 'ExpectedValue'
+                    }
+
+                    break
+                }
+
+                default
+                {
+                    $parameterNames += @{
+                        $currentParameter = $currentParameter
+                    }
+
+                    break
+                }
+            }
+        }
+
+        # This handles the named parameters in the command elements, added in alphabetical order.
+        foreach ($currentParameter in $parameterNames.Keys | Sort-Object)
+        {
+            $originalParameterName = $parameterNames.$currentParameter
+
+            $newExtentText += ' -{0} {1}' -f $currentParameter, $commandParameters.$originalParameterName.ExtentText
+        }
+    }
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertedCommand -f $CommandAst.Extent.Text, $newExtentText)
+
+    return $newExtentText
+}

--- a/source/Private/Convert-ShouldBeGreaterThan.ps1
+++ b/source/Private/Convert-ShouldBeGreaterThan.ps1
@@ -1,0 +1,202 @@
+<#
+    .SYNOPSIS
+        Converts a command `Should -BeGreaterThan` to the specified Pester syntax.
+
+    .DESCRIPTION
+        The Convert-ShouldBeGreaterThan function is used to convert a command `Should -BeGreaterThan` to
+        the specified Pester syntax.
+
+    .PARAMETER CommandAst
+        The CommandAst object representing the command to be converted.
+
+    .PARAMETER Pester6
+        Specifies that the command should be converted to Pester version 6 syntax.
+
+    .PARAMETER UseNamedParameters
+        Specifies whether to use named parameters in the converted syntax.
+
+    .PARAMETER UsePositionalParameters
+        Specifies whether to use positional parameters in the converted syntax,
+        where supported.
+
+    .EXAMPLE
+        $commandAst = [System.Management.Automation.Language.Parser]::ParseInput('Should -BeGreaterThan 2')
+        Convert-ShouldBeGreaterThan -CommandAst $commandAst -Pester6
+
+        This example converts the `Should -BeGreaterThan 2` command to Pester 6 syntax.
+
+    .NOTES
+        Pester 5 Syntax:
+            Should -BeGreaterThan [[-ActualValue] <Object>] [[-ExpectedValue] <Object>] [[-Because] <string>] [-Not]
+
+            Positional parameters:
+                Position 1: ExpectedValue
+                Position 2: Because
+                Position 3: ActualValue
+
+        Pester 6 Syntax:
+            Should-BeGreaterThan [[-Actual] <Object>] [-Expected] <Object> [-Because <String>]
+            Should-BeLessThan [[-Actual] <Object>] [-Expected] <Object> [-Because <String>]
+
+            Positional parameters:
+                Position 1: Expected
+                Position 2: Actual
+#>
+function Convert-ShouldBeGreaterThan
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.CommandAst]
+        $CommandAst,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Pester6')]
+        [System.Management.Automation.SwitchParameter]
+        $Pester6,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UseNamedParameters,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UsePositionalParameters
+    )
+
+    $assertBoundParameterParameters = @{
+        BoundParameterList     = $PSBoundParameters
+        MutuallyExclusiveList1 = @('UseNamedParameters')
+        MutuallyExclusiveList2 = @('UsePositionalParameters')
+    }
+
+    Assert-BoundParameter @assertBoundParameterParameters
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ParsingCommandAst -f $CommandAst.Extent.Text)
+
+    # Determine if the command is negated
+    $isNegated = Test-PesterCommandNegated -CommandAst $CommandAst
+
+    $sourceSyntaxVersion = Get-PesterCommandSyntaxVersion -CommandAst $CommandAst
+
+    # Parse the command elements and convert them to Pester 6 syntax
+    if ($PSCmdlet.ParameterSetName -eq 'Pester6')
+    {
+        Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertingFromTo -f $sourceSyntaxVersion, '6')
+
+        # Add the correct Pester command based on negation
+        if ($isNegated)
+        {
+            $newExtentText = 'Should-BeLessThan'
+        }
+        else
+        {
+            $newExtentText = 'Should-BeGreaterThan'
+        }
+
+        $getPesterCommandParameterParameters = @{
+            CommandAst          = $CommandAst
+            CommandName         = 'Should'
+            IgnoreParameter     = @(
+                'BeGreaterThan'
+                'GT'
+                'Not'
+            )
+            PositionalParameter = @(
+                'ExpectedValue'
+                'Because'
+                'ActualValue'
+            )
+        }
+
+        $commandParameters = Get-PesterCommandParameter @getPesterCommandParameterParameters
+
+        # Parameter 'Because' is only supported as named parameter in Pester 6 syntax.
+        if ($commandParameters.Because)
+        {
+            $commandParameters.Because.Positional = $false
+        }
+
+        # Determine if named or positional parameters should be forcibly used
+        if ($UseNamedParameters.IsPresent)
+        {
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+        }
+        elseif ($UsePositionalParameters.IsPresent)
+        {
+            # First set all to named parameters
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+
+            <#
+                If a previous positional parameter is missing then the ones behind
+                it cannot be set to positional.
+            #>
+            if ($commandParameters.ExpectedValue)
+            {
+                $commandParameters.ExpectedValue.Positional = $true
+
+                if ($commandParameters.ActualValue)
+                {
+                    $commandParameters.ActualValue.Positional = $true
+                }
+            }
+        }
+
+        $newExtentText += $commandParameters.ExpectedValue.Positional ? (' {0}' -f $commandParameters.ExpectedValue.ExtentText) : ''
+        $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
+
+        # Holds the new parameter names so they can be added in alphabetical order.
+        $parameterNames = @()
+
+        foreach ($currentParameter in $commandParameters.Keys)
+        {
+            if ($commandParameters.$currentParameter.Positional -eq $true)
+            {
+                continue
+            }
+
+            switch ($currentParameter)
+            {
+                'ActualValue'
+                {
+                    $parameterNames += @{
+                        Actual = 'ActualValue'
+                    }
+
+                    break
+                }
+
+                'ExpectedValue'
+                {
+                    $parameterNames += @{
+                        Expected = 'ExpectedValue'
+                    }
+
+                    break
+                }
+
+                default
+                {
+                    $parameterNames += @{
+                        $currentParameter = $currentParameter
+                    }
+
+                    break
+                }
+            }
+        }
+
+        # This handles the named parameters in the command elements, added in alphabetical order.
+        foreach ($currentParameter in $parameterNames.Keys | Sort-Object)
+        {
+            $originalParameterName = $parameterNames.$currentParameter
+
+            $newExtentText += ' -{0} {1}' -f $currentParameter, $commandParameters.$originalParameterName.ExtentText
+        }
+    }
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertedCommand -f $CommandAst.Extent.Text, $newExtentText)
+
+    return $newExtentText
+}

--- a/source/Private/Convert-ShouldBeLessOrEqual.ps1
+++ b/source/Private/Convert-ShouldBeLessOrEqual.ps1
@@ -1,0 +1,202 @@
+<#
+    .SYNOPSIS
+        Converts a command `Should -BeLessOrEqual` to the specified Pester syntax.
+
+    .DESCRIPTION
+        The Convert-ShouldBeLessOrEqual function is used to convert a command `Should -BeLessOrEqual` to
+        the specified Pester syntax.
+
+    .PARAMETER CommandAst
+        The CommandAst object representing the command to be converted.
+
+    .PARAMETER Pester6
+        Specifies that the command should be converted to Pester version 6 syntax.
+
+    .PARAMETER UseNamedParameters
+        Specifies whether to use named parameters in the converted syntax.
+
+    .PARAMETER UsePositionalParameters
+        Specifies whether to use positional parameters in the converted syntax,
+        where supported.
+
+    .EXAMPLE
+        $commandAst = [System.Management.Automation.Language.Parser]::ParseInput('Should -BeLessOrEqual 2')
+        Convert-ShouldBeLessOrEqual -CommandAst $commandAst -Pester6
+
+        This example converts the `Should -BeLessOrEqual 2` command to Pester 6 syntax.
+
+    .NOTES
+        Pester 5 Syntax:
+            Should -BeLessOrEqual [[-ActualValue] <Object>] [[-ExpectedValue] <Object>] [[-Because] <string>] [-Not]
+
+            Positional parameters:
+                Position 1: ExpectedValue
+                Position 2: Because
+                Position 3: ActualValue
+
+        Pester 6 Syntax:
+            Should-BeLessOrEqualOrEqual [[-Actual] <Object>] [-Expected] <Object> [-Because <String>]
+            Should-BeLessThanOrEqual [[-Actual] <Object>] [-Expected] <Object> [-Because <String>]
+
+            Positional parameters:
+                Position 1: Expected
+                Position 2: Actual
+#>
+function Convert-ShouldBeLessOrEqual
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.CommandAst]
+        $CommandAst,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Pester6')]
+        [System.Management.Automation.SwitchParameter]
+        $Pester6,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UseNamedParameters,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UsePositionalParameters
+    )
+
+    $assertBoundParameterParameters = @{
+        BoundParameterList     = $PSBoundParameters
+        MutuallyExclusiveList1 = @('UseNamedParameters')
+        MutuallyExclusiveList2 = @('UsePositionalParameters')
+    }
+
+    Assert-BoundParameter @assertBoundParameterParameters
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ParsingCommandAst -f $CommandAst.Extent.Text)
+
+    # Determine if the command is negated
+    $isNegated = Test-PesterCommandNegated -CommandAst $CommandAst
+
+    $sourceSyntaxVersion = Get-PesterCommandSyntaxVersion -CommandAst $CommandAst
+
+    # Parse the command elements and convert them to Pester 6 syntax
+    if ($PSCmdlet.ParameterSetName -eq 'Pester6')
+    {
+        Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertingFromTo -f $sourceSyntaxVersion, '6')
+
+        # Add the correct Pester command based on negation
+        if ($isNegated)
+        {
+            $newExtentText = 'Should-BeGreaterThanOrEqual'
+        }
+        else
+        {
+            $newExtentText = 'Should-BeLessThanOrEqual'
+        }
+
+        $getPesterCommandParameterParameters = @{
+            CommandAst          = $CommandAst
+            CommandName         = 'Should'
+            IgnoreParameter     = @(
+                'BeLessOrEqual'
+                'LE'
+                'Not'
+            )
+            PositionalParameter = @(
+                'ExpectedValue'
+                'Because'
+                'ActualValue'
+            )
+        }
+
+        $commandParameters = Get-PesterCommandParameter @getPesterCommandParameterParameters
+
+        # Parameter 'Because' is only supported as named parameter in Pester 6 syntax.
+        if ($commandParameters.Because)
+        {
+            $commandParameters.Because.Positional = $false
+        }
+
+        # Determine if named or positional parameters should be forcibly used
+        if ($UseNamedParameters.IsPresent)
+        {
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+        }
+        elseif ($UsePositionalParameters.IsPresent)
+        {
+            # First set all to named parameters
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+
+            <#
+                If a previous positional parameter is missing then the ones behind
+                it cannot be set to positional.
+            #>
+            if ($commandParameters.ExpectedValue)
+            {
+                $commandParameters.ExpectedValue.Positional = $true
+
+                if ($commandParameters.ActualValue)
+                {
+                    $commandParameters.ActualValue.Positional = $true
+                }
+            }
+        }
+
+        $newExtentText += $commandParameters.ExpectedValue.Positional ? (' {0}' -f $commandParameters.ExpectedValue.ExtentText) : ''
+        $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
+
+        # Holds the new parameter names so they can be added in alphabetical order.
+        $parameterNames = @()
+
+        foreach ($currentParameter in $commandParameters.Keys)
+        {
+            if ($commandParameters.$currentParameter.Positional -eq $true)
+            {
+                continue
+            }
+
+            switch ($currentParameter)
+            {
+                'ActualValue'
+                {
+                    $parameterNames += @{
+                        Actual = 'ActualValue'
+                    }
+
+                    break
+                }
+
+                'ExpectedValue'
+                {
+                    $parameterNames += @{
+                        Expected = 'ExpectedValue'
+                    }
+
+                    break
+                }
+
+                default
+                {
+                    $parameterNames += @{
+                        $currentParameter = $currentParameter
+                    }
+
+                    break
+                }
+            }
+        }
+
+        # This handles the named parameters in the command elements, added in alphabetical order.
+        foreach ($currentParameter in $parameterNames.Keys | Sort-Object)
+        {
+            $originalParameterName = $parameterNames.$currentParameter
+
+            $newExtentText += ' -{0} {1}' -f $currentParameter, $commandParameters.$originalParameterName.ExtentText
+        }
+    }
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertedCommand -f $CommandAst.Extent.Text, $newExtentText)
+
+    return $newExtentText
+}

--- a/source/Private/Convert-ShouldBeLessThan.ps1
+++ b/source/Private/Convert-ShouldBeLessThan.ps1
@@ -1,0 +1,202 @@
+<#
+    .SYNOPSIS
+        Converts a command `Should -BeLessThan` to the specified Pester syntax.
+
+    .DESCRIPTION
+        The Convert-ShouldBeLessThan function is used to convert a command `Should -BeLessThan` to
+        the specified Pester syntax.
+
+    .PARAMETER CommandAst
+        The CommandAst object representing the command to be converted.
+
+    .PARAMETER Pester6
+        Specifies that the command should be converted to Pester version 6 syntax.
+
+    .PARAMETER UseNamedParameters
+        Specifies whether to use named parameters in the converted syntax.
+
+    .PARAMETER UsePositionalParameters
+        Specifies whether to use positional parameters in the converted syntax,
+        where supported.
+
+    .EXAMPLE
+        $commandAst = [System.Management.Automation.Language.Parser]::ParseInput('Should -BeLessThan 2')
+        Convert-ShouldBeLessThan -CommandAst $commandAst -Pester6
+
+        This example converts the `Should -BeLessThan 2` command to Pester 6 syntax.
+
+    .NOTES
+        Pester 5 Syntax:
+            Should -BeLessThan [[-ActualValue] <Object>] [[-ExpectedValue] <Object>] [[-Because] <string>] [-Not]
+
+            Positional parameters:
+                Position 1: ExpectedValue
+                Position 2: Because
+                Position 3: ActualValue
+
+        Pester 6 Syntax:
+            Should-BeLessThan [[-Actual] <Object>] [-Expected] <Object> [-Because <String>]
+            Should-BeGreaterThan [[-Actual] <Object>] [-Expected] <Object> [-Because <String>]
+
+            Positional parameters:
+                Position 1: Expected
+                Position 2: Actual
+#>
+function Convert-ShouldBeLessThan
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.CommandAst]
+        $CommandAst,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Pester6')]
+        [System.Management.Automation.SwitchParameter]
+        $Pester6,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UseNamedParameters,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UsePositionalParameters
+    )
+
+    $assertBoundParameterParameters = @{
+        BoundParameterList     = $PSBoundParameters
+        MutuallyExclusiveList1 = @('UseNamedParameters')
+        MutuallyExclusiveList2 = @('UsePositionalParameters')
+    }
+
+    Assert-BoundParameter @assertBoundParameterParameters
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ParsingCommandAst -f $CommandAst.Extent.Text)
+
+    # Determine if the command is negated
+    $isNegated = Test-PesterCommandNegated -CommandAst $CommandAst
+
+    $sourceSyntaxVersion = Get-PesterCommandSyntaxVersion -CommandAst $CommandAst
+
+    # Parse the command elements and convert them to Pester 6 syntax
+    if ($PSCmdlet.ParameterSetName -eq 'Pester6')
+    {
+        Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertingFromTo -f $sourceSyntaxVersion, '6')
+
+        # Add the correct Pester command based on negation
+        if ($isNegated)
+        {
+            $newExtentText = 'Should-BeGreaterThan'
+        }
+        else
+        {
+            $newExtentText = 'Should-BeLessThan'
+        }
+
+        $getPesterCommandParameterParameters = @{
+            CommandAst          = $CommandAst
+            CommandName         = 'Should'
+            IgnoreParameter     = @(
+                'BeLessThan'
+                'LT'
+                'Not'
+            )
+            PositionalParameter = @(
+                'ExpectedValue'
+                'Because'
+                'ActualValue'
+            )
+        }
+
+        $commandParameters = Get-PesterCommandParameter @getPesterCommandParameterParameters
+
+        # Parameter 'Because' is only supported as named parameter in Pester 6 syntax.
+        if ($commandParameters.Because)
+        {
+            $commandParameters.Because.Positional = $false
+        }
+
+        # Determine if named or positional parameters should be forcibly used
+        if ($UseNamedParameters.IsPresent)
+        {
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+        }
+        elseif ($UsePositionalParameters.IsPresent)
+        {
+            # First set all to named parameters
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+
+            <#
+                If a previous positional parameter is missing then the ones behind
+                it cannot be set to positional.
+            #>
+            if ($commandParameters.ExpectedValue)
+            {
+                $commandParameters.ExpectedValue.Positional = $true
+
+                if ($commandParameters.ActualValue)
+                {
+                    $commandParameters.ActualValue.Positional = $true
+                }
+            }
+        }
+
+        $newExtentText += $commandParameters.ExpectedValue.Positional ? (' {0}' -f $commandParameters.ExpectedValue.ExtentText) : ''
+        $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
+
+        # Holds the new parameter names so they can be added in alphabetical order.
+        $parameterNames = @()
+
+        foreach ($currentParameter in $commandParameters.Keys)
+        {
+            if ($commandParameters.$currentParameter.Positional -eq $true)
+            {
+                continue
+            }
+
+            switch ($currentParameter)
+            {
+                'ActualValue'
+                {
+                    $parameterNames += @{
+                        Actual = 'ActualValue'
+                    }
+
+                    break
+                }
+
+                'ExpectedValue'
+                {
+                    $parameterNames += @{
+                        Expected = 'ExpectedValue'
+                    }
+
+                    break
+                }
+
+                default
+                {
+                    $parameterNames += @{
+                        $currentParameter = $currentParameter
+                    }
+
+                    break
+                }
+            }
+        }
+
+        # This handles the named parameters in the command elements, added in alphabetical order.
+        foreach ($currentParameter in $parameterNames.Keys | Sort-Object)
+        {
+            $originalParameterName = $parameterNames.$currentParameter
+
+            $newExtentText += ' -{0} {1}' -f $currentParameter, $commandParameters.$originalParameterName.ExtentText
+        }
+    }
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertedCommand -f $CommandAst.Extent.Text, $newExtentText)
+
+    return $newExtentText
+}

--- a/source/Public/Convert-PesterSyntax.ps1
+++ b/source/Public/Convert-PesterSyntax.ps1
@@ -285,6 +285,34 @@ function Convert-PesterSyntax
                                 break
                             }
 
+                            'BeGreaterThan'
+                            {
+                                $newExtentText = Convert-ShouldBeGreaterThan -CommandAst $commandAst @convertParameters -ErrorAction 'Stop'
+
+                                break
+                            }
+
+                            'BeLessThan'
+                            {
+                                $newExtentText = Convert-ShouldBeLessThan -CommandAst $commandAst @convertParameters -ErrorAction 'Stop'
+
+                                break
+                            }
+
+                            'BeGreaterOrEqual'
+                            {
+                                $newExtentText = Convert-ShouldBeGreaterOrEqual -CommandAst $commandAst @convertParameters -ErrorAction 'Stop'
+
+                                break
+                            }
+
+                            'BeLessOrEqual'
+                            {
+                                $newExtentText = Convert-ShouldBeLessOrEqual -CommandAst $commandAst @convertParameters -ErrorAction 'Stop'
+
+                                break
+                            }
+
                             default
                             {
                                 Write-Warning -Message ($script:localizedData.Convert_PesterSyntax_Warning_UnsupportedCommandOperator -f $operatorName, $commandAst.Extent.Text)

--- a/source/WikiSource/Pester_v5_Conversion.md
+++ b/source/WikiSource/Pester_v5_Conversion.md
@@ -20,6 +20,10 @@ Should operator name | Affirm | Negate | Notes
 Be | `Should-Be` | `Should-NotBe` | -
 BeExactly | `Should-Be -CaseSensitive` | `Should-NotBe -CaseSensitive` | -
 BeFalse | `Should-BeFalse` | `Should-BeTrue` | -
+BeGreaterOrEqual | `Should-BeGreaterThanOrEqual` | `Should-BeLessThanOrEqual` | -
+BeGreaterThan | `Should-BeGreaterThan` | `Should-BeLessThan` | -
+BeLessOrEqual | `Should-BeLessThanOrEqual` | `Should-BeGreaterThanOrEqual` | -
+BeLessThan | `Should-BeLessThan` | `Should-BeGreaterThan` | -
 BeNullOrEmpty | `Should-BeFalsy` | `Should-BeTruthy` | See 2)
 BeOfType | `Should-HaveType` | `Should-NotHaveType` | -
 BeTrue | `Should-BeTrue` | `Should-BeFalse` | -

--- a/tests/Unit/Private/Convert-ShouldBeExactly.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeExactly.tests.ps1
@@ -252,7 +252,7 @@ Describe 'Convert-ShouldBeExactly' {
         }
 
         Context 'When the tests are negated' {
-            It 'Should convert `Should -Not -Be ''ExpectedString''` correctly' {
+            It 'Should convert `Should -Not -BeExactly ''ExpectedString''` correctly' {
                 InModuleScope -ScriptBlock {
                     $mockCommandAstPester5 = {
                         Should -Not -BeExactly 'ExpectedString'

--- a/tests/Unit/Private/Convert-ShouldBeGreaterOrEqual.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeGreaterOrEqual.tests.ps1
@@ -1,0 +1,494 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'PesterConverter'
+
+    Import-Module -Name $script:dscModuleName
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+}
+
+Describe 'Convert-ShouldBeGreaterOrEqual' {
+    Context 'When converting Pester 5 syntax to Pester 6 syntax' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues['Convert-ShouldBeGreaterOrEqual:Pester6'] = $true
+            }
+        }
+
+        AfterAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues.Remove('Convert-ShouldBeGreaterOrEqual:Pester6')
+            }
+        }
+
+        Context 'When the tests are affirming' {
+            It 'Should convert `Should -BeGreaterOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterOrEqual $numericValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual $numericValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual $numericValue'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 2 -BeGreaterOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 2 -BeGreaterOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 -Actual 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterOrEqual 2 -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual 2 -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 -Actual 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 2 -BeGreaterOrEqual -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 2 -BeGreaterOrEqual -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterOrEqual -ActualValue 2 -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual -ActualValue 2 -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterOrEqual -ExpectedValue 2 -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual -ExpectedValue 2 -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue 2 -BeGreaterOrEqual -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 2 -BeGreaterOrEqual -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue 2 -ActualValue 2 -BeGreaterOrEqual` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 2 -ActualValue 2 -BeGreaterOrEqual
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -Not:$false -BeGreaterOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$false -BeGreaterOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterOrEqual (Get-Something)` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        function Get-Something { return 2 }
+                        2 | Should -BeGreaterOrEqual (Get-Something)
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual (Get-Something)'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterOrEqual 2 -Because ''mock should test correct value'' 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual 2 -Because 'mock should test correct value' 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 2 -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterOrEqual 2 ''mock should test correct value'' 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual 2 'mock should test correct value' 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 3 -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should 2 ''mock should test correct value'' 3 -BeGreaterOrEqual` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should 2 'mock should test correct value' 3 -BeGreaterOrEqual
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 3 -Because ''mock should test correct value'''
+                }
+            }
+        }
+
+        Context 'When the tests are negated' {
+            It 'Should convert `Should -Not -BeGreaterOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeGreaterOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterOrEqual 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2'
+                }
+            }
+
+            It 'Should convert `Should -Not -BeGreaterOrEqual $anyValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeGreaterOrEqual $anyValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterOrEqual $anyValue -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual $anyValue -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -Not:$true -BeGreaterOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$true -BeGreaterOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2'
+                }
+            }
+
+            It 'Should convert `Should -Not -ActualValue 3 -BeGreaterOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -ActualValue 3 -BeGreaterOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -Not -BeGreaterOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -Not -BeGreaterOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeGreaterOrEqual 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeGreaterOrEqual 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterOrEqual 2 -ActualValue 3 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual 2 -ActualValue 3 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterOrEqual 2 -Not -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual 2 -Not -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -Not -BeGreaterOrEqual 2 -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeGreaterOrEqual 2 -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeGreaterOrEqual -Not -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeGreaterOrEqual -Not -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual -Actual 3 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -Not -BeGreaterOrEqual -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -Not -BeGreaterOrEqual -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual -Actual 3 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeGreaterOrEqual -ExpectedValue 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeGreaterOrEqual -ExpectedValue 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual -Actual 3 -Expected 2'
+                }
+            }
+        }
+
+        Context 'When alias operator name is used' {
+            It 'Should convert `Should -GE 2 -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -GE 2 -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5 -UseNamedParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual -Actual 3 -Expected 2'
+                }
+            }
+        }
+
+        Context 'When tests should always use named parameters' {
+            It 'Should convert `Should -BeGreaterOrEqual 2 -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterOrEqual 2 -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5 -UseNamedParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual -Actual 3 -Expected 2'
+                }
+            }
+        }
+
+        Context 'When tests should always use positional parameters' {
+            Context 'When the tests are affirming' {
+                It 'Should convert `Should -BeGreaterOrEqual 2 -ActualValue 3` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeGreaterOrEqual 2 -ActualValue 3
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 3'
+                    }
+                }
+
+                It 'Should convert `Should -BeGreaterOrEqual 2 -ActualValue 3 -Because "this must return true"` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeGreaterOrEqual 2 -ActualValue 3 -Because "this must return true"
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 3 -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -BeGreaterOrEqual 2 -Because "this must return true" -ActualValue 3` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeGreaterOrEqual 2 -Because "this must return true" -ActualValue 3
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 3 -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -Because "this must return true" -ActualValue 3 -BeGreaterOrEqual 2` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -Because "this must return true" -ActualValue 3 -BeGreaterOrEqual 2
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 3 -Because "this must return true"'
+                    }
+                }
+            }
+
+            Context 'When the tests are negated' {
+                It 'Should convert `Should -BeGreaterOrEqual 2 -ActualValue 3 -Because "this must return true" -Not` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeGreaterOrEqual 2 -ActualValue 3 -Because "this must return true" -Not
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeGreaterOrEqual -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 3 -Because "this must return true"'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Unit/Private/Convert-ShouldBeGreaterThan.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeGreaterThan.tests.ps1
@@ -1,0 +1,494 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'PesterConverter'
+
+    Import-Module -Name $script:dscModuleName
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+}
+
+Describe 'Convert-ShouldBeGreaterThan' {
+    Context 'When converting Pester 5 syntax to Pester 6 syntax' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues['Convert-ShouldBeGreaterThan:Pester6'] = $true
+            }
+        }
+
+        AfterAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues.Remove('Convert-ShouldBeGreaterThan:Pester6')
+            }
+        }
+
+        Context 'When the tests are affirming' {
+            It 'Should convert `Should -BeGreaterThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterThan $numericValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan $numericValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan $numericValue'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 2 -BeGreaterThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 2 -BeGreaterThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 -Actual 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterThan 2 -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan 2 -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 -Actual 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 2 -BeGreaterThan -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 2 -BeGreaterThan -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterThan -ActualValue 2 -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan -ActualValue 2 -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterThan -ExpectedValue 2 -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan -ExpectedValue 2 -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue 2 -BeGreaterThan -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 2 -BeGreaterThan -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue 2 -ActualValue 2 -BeGreaterThan` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 2 -ActualValue 2 -BeGreaterThan
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -Not:$false -BeGreaterThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$false -BeGreaterThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterThan (Get-Something)` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        function Get-Something { return 2 }
+                        2 | Should -BeGreaterThan (Get-Something)
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan (Get-Something)'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterThan 2 -Because ''mock should test correct value'' 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan 2 -Because 'mock should test correct value' 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 2 -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterThan 2 ''mock should test correct value'' 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan 2 'mock should test correct value' 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 3 -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should 2 ''mock should test correct value'' 3 -BeGreaterThan` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should 2 'mock should test correct value' 3 -BeGreaterThan
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 3 -Because ''mock should test correct value'''
+                }
+            }
+        }
+
+        Context 'When the tests are negated' {
+            It 'Should convert `Should -Not -BeGreaterThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeGreaterThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterThan 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2'
+                }
+            }
+
+            It 'Should convert `Should -Not -BeGreaterThan $anyValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeGreaterThan $anyValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterThan $anyValue -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan $anyValue -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -Not:$true -BeGreaterThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$true -BeGreaterThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2'
+                }
+            }
+
+            It 'Should convert `Should -Not -ActualValue 3 -BeGreaterThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -ActualValue 3 -BeGreaterThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -Not -BeGreaterThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -Not -BeGreaterThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeGreaterThan 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeGreaterThan 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterThan 2 -ActualValue 3 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan 2 -ActualValue 3 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -BeGreaterThan 2 -Not -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan 2 -Not -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -Not -BeGreaterThan 2 -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeGreaterThan 2 -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeGreaterThan -Not -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeGreaterThan -Not -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan -Actual 3 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -Not -BeGreaterThan -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -Not -BeGreaterThan -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan -Actual 3 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeGreaterThan -ExpectedValue 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeGreaterThan -ExpectedValue 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan -Actual 3 -Expected 2'
+                }
+            }
+        }
+
+        Context 'When alias operator name is used' {
+            It 'Should convert `Should -GT 2 -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -GT 2 -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5 -UseNamedParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan -Actual 3 -Expected 2'
+                }
+            }
+        }
+
+        Context 'When tests should always use named parameters' {
+            It 'Should convert `Should -BeGreaterThan 2 -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeGreaterThan 2 -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5 -UseNamedParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan -Actual 3 -Expected 2'
+                }
+            }
+        }
+
+        Context 'When tests should always use positional parameters' {
+            Context 'When the tests are affirming' {
+                It 'Should convert `Should -BeGreaterThan 2 -ActualValue 3` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeGreaterThan 2 -ActualValue 3
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 3'
+                    }
+                }
+
+                It 'Should convert `Should -BeGreaterThan 2 -ActualValue 3 -Because "this must return true"` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeGreaterThan 2 -ActualValue 3 -Because "this must return true"
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 3 -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -BeGreaterThan 2 -Because "this must return true" -ActualValue 3` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeGreaterThan 2 -Because "this must return true" -ActualValue 3
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 3 -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -Because "this must return true" -ActualValue 3 -BeGreaterThan 2` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -Because "this must return true" -ActualValue 3 -BeGreaterThan 2
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 3 -Because "this must return true"'
+                    }
+                }
+            }
+
+            Context 'When the tests are negated' {
+                It 'Should convert `Should -BeGreaterThan 2 -ActualValue 3 -Because "this must return true" -Not` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeGreaterThan 2 -ActualValue 3 -Because "this must return true" -Not
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeGreaterThan -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 3 -Because "this must return true"'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Unit/Private/Convert-ShouldBeLessOrEqual.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeLessOrEqual.tests.ps1
@@ -1,0 +1,494 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'PesterConverter'
+
+    Import-Module -Name $script:dscModuleName
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+}
+
+Describe 'Convert-ShouldBeLessOrEqual' {
+    Context 'When converting Pester 5 syntax to Pester 6 syntax' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues['Convert-ShouldBeLessOrEqual:Pester6'] = $true
+            }
+        }
+
+        AfterAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues.Remove('Convert-ShouldBeLessOrEqual:Pester6')
+            }
+        }
+
+        Context 'When the tests are affirming' {
+            It 'Should convert `Should -BeLessOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessOrEqual $numericValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual $numericValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual $numericValue'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 2 -BeLessOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 2 -BeLessOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 -Actual 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessOrEqual 2 -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual 2 -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 -Actual 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 2 -BeLessOrEqual -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 2 -BeLessOrEqual -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessOrEqual -ActualValue 2 -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual -ActualValue 2 -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessOrEqual -ExpectedValue 2 -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual -ExpectedValue 2 -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue 2 -BeLessOrEqual -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 2 -BeLessOrEqual -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue 2 -ActualValue 2 -BeLessOrEqual` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 2 -ActualValue 2 -BeLessOrEqual
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -Not:$false -BeLessOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$false -BeLessOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessOrEqual (Get-Something)` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        function Get-Something { return 2 }
+                        2 | Should -BeLessOrEqual (Get-Something)
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual (Get-Something)'
+                }
+            }
+
+            It 'Should convert `Should -BeLessOrEqual 2 -Because ''mock should test correct value'' 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual 2 -Because 'mock should test correct value' 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 2 -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should -BeLessOrEqual 2 ''mock should test correct value'' 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual 2 'mock should test correct value' 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 3 -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should 2 ''mock should test correct value'' 3 -BeLessOrEqual` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should 2 'mock should test correct value' 3 -BeLessOrEqual
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 3 -Because ''mock should test correct value'''
+                }
+            }
+        }
+
+        Context 'When the tests are negated' {
+            It 'Should convert `Should -Not -BeLessOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLessOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessOrEqual 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2'
+                }
+            }
+
+            It 'Should convert `Should -Not -BeLessOrEqual $anyValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLessOrEqual $anyValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -BeLessOrEqual $anyValue -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual $anyValue -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -Not:$true -BeLessOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$true -BeLessOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2'
+                }
+            }
+
+            It 'Should convert `Should -Not -ActualValue 3 -BeLessOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -ActualValue 3 -BeLessOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -Not -BeLessOrEqual 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -Not -BeLessOrEqual 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeLessOrEqual 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeLessOrEqual 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -BeLessOrEqual 2 -ActualValue 3 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual 2 -ActualValue 3 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -BeLessOrEqual 2 -Not -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual 2 -Not -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -Not -BeLessOrEqual 2 -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLessOrEqual 2 -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeLessOrEqual -Not -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeLessOrEqual -Not -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual -Actual 3 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -Not -BeLessOrEqual -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -Not -BeLessOrEqual -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual -Actual 3 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeLessOrEqual -ExpectedValue 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeLessOrEqual -ExpectedValue 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual -Actual 3 -Expected 2'
+                }
+            }
+        }
+
+        Context 'When alias operator name is used' {
+            It 'Should convert `Should -LE 2 -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -LE 2 -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5 -UseNamedParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual -Actual 3 -Expected 2'
+                }
+            }
+        }
+
+        Context 'When tests should always use named parameters' {
+            It 'Should convert `Should -BeLessOrEqual 2 -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessOrEqual 2 -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5 -UseNamedParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual -Actual 3 -Expected 2'
+                }
+            }
+        }
+
+        Context 'When tests should always use positional parameters' {
+            Context 'When the tests are affirming' {
+                It 'Should convert `Should -BeLessOrEqual 2 -ActualValue 3` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLessOrEqual 2 -ActualValue 3
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 3'
+                    }
+                }
+
+                It 'Should convert `Should -BeLessOrEqual 2 -ActualValue 3 -Because "this must return true"` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLessOrEqual 2 -ActualValue 3 -Because "this must return true"
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 3 -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -BeLessOrEqual 2 -Because "this must return true" -ActualValue 3` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLessOrEqual 2 -Because "this must return true" -ActualValue 3
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 3 -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -Because "this must return true" -ActualValue 3 -BeLessOrEqual 2` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -Because "this must return true" -ActualValue 3 -BeLessOrEqual 2
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLessThanOrEqual 2 3 -Because "this must return true"'
+                    }
+                }
+            }
+
+            Context 'When the tests are negated' {
+                It 'Should convert `Should -BeLessOrEqual 2 -ActualValue 3 -Because "this must return true" -Not` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLessOrEqual 2 -ActualValue 3 -Because "this must return true" -Not
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLessOrEqual -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeGreaterThanOrEqual 2 3 -Because "this must return true"'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Unit/Private/Convert-ShouldBeLessThan.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeLessThan.tests.ps1
@@ -1,0 +1,494 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'PesterConverter'
+
+    Import-Module -Name $script:dscModuleName
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+}
+
+Describe 'Convert-ShouldBeLessThan' {
+    Context 'When converting Pester 5 syntax to Pester 6 syntax' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues['Convert-ShouldBeLessThan:Pester6'] = $true
+            }
+        }
+
+        AfterAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues.Remove('Convert-ShouldBeLessThan:Pester6')
+            }
+        }
+
+        Context 'When the tests are affirming' {
+            It 'Should convert `Should -BeLessThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessThan $numericValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan $numericValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan $numericValue'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 2 -BeLessThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 2 -BeLessThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 -Actual 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessThan 2 -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan 2 -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 -Actual 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 2 -BeLessThan -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 2 -BeLessThan -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessThan -ActualValue 2 -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan -ActualValue 2 -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessThan -ExpectedValue 2 -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan -ExpectedValue 2 -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue 2 -BeLessThan -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 2 -BeLessThan -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue 2 -ActualValue 2 -BeLessThan` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 2 -ActualValue 2 -BeLessThan
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan -Actual 2 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -Not:$false -BeLessThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$false -BeLessThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessThan (Get-Something)` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        function Get-Something { return 2 }
+                        2 | Should -BeLessThan (Get-Something)
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan (Get-Something)'
+                }
+            }
+
+            It 'Should convert `Should -BeLessThan 2 -Because ''mock should test correct value'' 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan 2 -Because 'mock should test correct value' 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 2 -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should -BeLessThan 2 ''mock should test correct value'' 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan 2 'mock should test correct value' 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 3 -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should 2 ''mock should test correct value'' 3 -BeLessThan` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should 2 'mock should test correct value' 3 -BeLessThan
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 3 -Because ''mock should test correct value'''
+                }
+            }
+        }
+
+        Context 'When the tests are negated' {
+            It 'Should convert `Should -Not -BeLessThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLessThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2'
+                }
+            }
+
+            It 'Should convert `Should -BeLessThan 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2'
+                }
+            }
+
+            It 'Should convert `Should -Not -BeLessThan $anyValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLessThan $anyValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -BeLessThan $anyValue -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan $anyValue -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -Not:$true -BeLessThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$true -BeLessThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2'
+                }
+            }
+
+            It 'Should convert `Should -Not -ActualValue 3 -BeLessThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -ActualValue 3 -BeLessThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -Not -BeLessThan 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -Not -BeLessThan 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeLessThan 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeLessThan 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -BeLessThan 2 -ActualValue 3 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan 2 -ActualValue 3 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -BeLessThan 2 -Not -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan 2 -Not -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -Not -BeLessThan 2 -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLessThan 2 -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 -Actual 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeLessThan -Not -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeLessThan -Not -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan -Actual 3 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -Not -BeLessThan -ExpectedValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -Not -BeLessThan -ExpectedValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan -Actual 3 -Expected 2'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue 3 -BeLessThan -ExpectedValue 2 -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 3 -BeLessThan -ExpectedValue 2 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan -Actual 3 -Expected 2'
+                }
+            }
+        }
+
+        Context 'When alias operator name is used' {
+            It 'Should convert `Should -LT 3 -ActualValue 2` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -LT 3 -ActualValue 2
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5 -UseNamedParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan -Actual 2 -Expected 3'
+                }
+            }
+        }
+
+        Context 'When tests should always use named parameters' {
+            It 'Should convert `Should -BeLessThan 2 -ActualValue 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLessThan 2 -ActualValue 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5 -UseNamedParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLessThan -Actual 3 -Expected 2'
+                }
+            }
+        }
+
+        Context 'When tests should always use positional parameters' {
+            Context 'When the tests are affirming' {
+                It 'Should convert `Should -BeLessThan 2 -ActualValue 3` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLessThan 2 -ActualValue 3
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 3'
+                    }
+                }
+
+                It 'Should convert `Should -BeLessThan 2 -ActualValue 3 -Because "this must return true"` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLessThan 2 -ActualValue 3 -Because "this must return true"
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 3 -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -BeLessThan 2 -Because "this must return true" -ActualValue 3` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLessThan 2 -Because "this must return true" -ActualValue 3
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 3 -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -Because "this must return true" -ActualValue 3 -BeLessThan 2` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -Because "this must return true" -ActualValue 3 -BeLessThan 2
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLessThan 2 3 -Because "this must return true"'
+                    }
+                }
+            }
+
+            Context 'When the tests are negated' {
+                It 'Should convert `Should -BeLessThan 2 -ActualValue 3 -Because "this must return true" -Not` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLessThan 2 -ActualValue 3 -Because "this must return true" -Not
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLessThan -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeGreaterThan 2 3 -Because "this must return true"'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Unit/Public/Convert-PesterSyntax.tests.ps1
+++ b/tests/Unit/Public/Convert-PesterSyntax.tests.ps1
@@ -716,6 +716,242 @@ Describe 'Convert-PesterSyntax' {
             }
         }
 
+        Context 'When converting Should -BeGreaterThan' {
+            BeforeAll {
+                $mockAstExtentText = {
+                    Describe 'Should -BeGreaterThan' {
+                        It 'Should -BeGreaterThan' {
+                            3 | Should -BeGreaterThan 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $mockScriptFilePath = Join-Path -Path $TestDrive -ChildPath 'Mock.Tests.ps1'
+
+                Set-Content -Path $mockScriptFilePath -Value $mockAstExtentText -Encoding 'utf8'
+            }
+
+            It 'Should return the correct converted script' {
+                $mockExpectedConvertedScript = {
+
+                    Describe 'Should -BeGreaterThan' {
+                        It 'Should -BeGreaterThan' {
+                            3 | Should-BeGreaterThan 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+
+            It 'Should return the correct converted script using named parameters' {
+                $mockExpectedConvertedScript = {
+                    Describe 'Should -BeGreaterThan' {
+                        It 'Should -BeGreaterThan' {
+                            3 | Should-BeGreaterThan -Because 'BecauseString' -Expected 2
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -UseNamedParameters -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+
+            It 'Should return the correct converted script using positional parameters' {
+                $mockExpectedConvertedScript = {
+                    Describe 'Should -BeGreaterThan' {
+                        It 'Should -BeGreaterThan' {
+                            3 | Should-BeGreaterThan 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -UsePositionalParameters -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+        }
+
+        Context 'When converting Should -BeLessThan' {
+            BeforeAll {
+                $mockAstExtentText = {
+                    Describe 'Should -BeLessThan' {
+                        It 'Should -BeLessThan' {
+                            3 | Should -BeLessThan 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $mockScriptFilePath = Join-Path -Path $TestDrive -ChildPath 'Mock.Tests.ps1'
+
+                Set-Content -Path $mockScriptFilePath -Value $mockAstExtentText -Encoding 'utf8'
+            }
+
+            It 'Should return the correct converted script' {
+                $mockExpectedConvertedScript = {
+
+                    Describe 'Should -BeLessThan' {
+                        It 'Should -BeLessThan' {
+                            3 | Should-BeLessThan 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+
+            It 'Should return the correct converted script using named parameters' {
+                $mockExpectedConvertedScript = {
+                    Describe 'Should -BeLessThan' {
+                        It 'Should -BeLessThan' {
+                            3 | Should-BeLessThan -Because 'BecauseString' -Expected 2
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -UseNamedParameters -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+
+            It 'Should return the correct converted script using positional parameters' {
+                $mockExpectedConvertedScript = {
+                    Describe 'Should -BeLessThan' {
+                        It 'Should -BeLessThan' {
+                            3 | Should-BeLessThan 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -UsePositionalParameters -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+        }
+
+        Context 'When converting Should -BeGreaterOrEqual' {
+            BeforeAll {
+                $mockAstExtentText = {
+                    Describe 'Should -BeGreaterOrEqual' {
+                        It 'Should -BeGreaterOrEqual' {
+                            3 | Should -BeGreaterOrEqual 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $mockScriptFilePath = Join-Path -Path $TestDrive -ChildPath 'Mock.Tests.ps1'
+
+                Set-Content -Path $mockScriptFilePath -Value $mockAstExtentText -Encoding 'utf8'
+            }
+
+            It 'Should return the correct converted script' {
+                $mockExpectedConvertedScript = {
+
+                    Describe 'Should -BeGreaterOrEqual' {
+                        It 'Should -BeGreaterOrEqual' {
+                            3 | Should-BeGreaterThanOrEqual 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+
+            It 'Should return the correct converted script using named parameters' {
+                $mockExpectedConvertedScript = {
+                    Describe 'Should -BeGreaterOrEqual' {
+                        It 'Should -BeGreaterOrEqual' {
+                            3 | Should-BeGreaterThanOrEqual -Because 'BecauseString' -Expected 2
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -UseNamedParameters -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+
+            It 'Should return the correct converted script using positional parameters' {
+                $mockExpectedConvertedScript = {
+                    Describe 'Should -BeGreaterOrEqual' {
+                        It 'Should -BeGreaterOrEqual' {
+                            3 | Should-BeGreaterThanOrEqual 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -UsePositionalParameters -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+        }
+
+        Context 'When converting Should -BeLessOrEqual' {
+            BeforeAll {
+                $mockAstExtentText = {
+                    Describe 'Should -BeLessOrEqual' {
+                        It 'Should -BeLessOrEqual' {
+                            3 | Should -BeLessOrEqual 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $mockScriptFilePath = Join-Path -Path $TestDrive -ChildPath 'Mock.Tests.ps1'
+
+                Set-Content -Path $mockScriptFilePath -Value $mockAstExtentText -Encoding 'utf8'
+            }
+
+            It 'Should return the correct converted script' {
+                $mockExpectedConvertedScript = {
+
+                    Describe 'Should -BeLessOrEqual' {
+                        It 'Should -BeLessOrEqual' {
+                            3 | Should-BeLessThanOrEqual 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+
+            It 'Should return the correct converted script using named parameters' {
+                $mockExpectedConvertedScript = {
+                    Describe 'Should -BeLessOrEqual' {
+                        It 'Should -BeLessOrEqual' {
+                            3 | Should-BeLessThanOrEqual -Because 'BecauseString' -Expected 2
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -UseNamedParameters -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+
+            It 'Should return the correct converted script using positional parameters' {
+                $mockExpectedConvertedScript = {
+                    Describe 'Should -BeLessOrEqual' {
+                        It 'Should -BeLessOrEqual' {
+                            3 | Should-BeLessThanOrEqual 2 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -UsePositionalParameters -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+        }
+
         Context 'When converting several files' {
             BeforeAll {
                 $mockAstExtentText = {


### PR DESCRIPTION

#### Pull Request (PR) description
- Add support for additional Should operators:
  - `Should-BeGreaterThan`
  - `Should-BeGreaterOrEqual`
  - `Should-BeLessThan`
  - `Should-BeLessOrEqual`.

#### This Pull Request (PR) fixes the following issues

- Fixes #7 
- Fixes #8 
- Fixes #10 
- Fixes #11 

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Documentation added/updated in README.md and source/WikiSource.
- [x] Comment-based help added/updated for all new/changed functions.
- [x] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where applicable). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/PesterConverter/23)
<!-- Reviewable:end -->
