### PR TITLE
Add support for `Should` operator `BeLike*`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Public commands:
   - `Convert-PesterSyntax`
-- Add support for additional Should operators:
-  - `Should-BeGreaterThan`
-  - `Should-BeGreaterOrEqual`
-  - `Should-BeLessThan`
-  - `Should-BeLessOrEqual`.
+- Add support for Should operators:
+  - Be
+  - BeExactly
+  - BeFalse
+  - BeGreaterOrEqual
+  - BeGreaterThan
+  - BeLessOrEqual
+  - BeLessThan
+  - BeLike
+  - BeLikeExactly
+  - BeNullOrEmpty
+  - BeOfType
+  - BeTrue
+  - Contain
+  - Match
+  - MatchExactly
+  - Throw
 
 ### Fixed
 

--- a/source/Private/Convert-ShouldBeLike.ps1
+++ b/source/Private/Convert-ShouldBeLike.ps1
@@ -1,0 +1,201 @@
+<#
+    .SYNOPSIS
+        Converts a command `Should -BeLike` to the specified Pester syntax.
+
+    .DESCRIPTION
+        The Convert-ShouldBeLike function is used to convert a command `Should -BeLike` to
+        the specified Pester syntax.
+
+    .PARAMETER CommandAst
+        The CommandAst object representing the command to be converted.
+
+    .PARAMETER Pester6
+        Specifies that the command should be converted to Pester version 6 syntax.
+
+    .PARAMETER UseNamedParameters
+        Specifies whether to use named parameters in the converted syntax.
+
+    .PARAMETER UsePositionalParameters
+        Specifies whether to use positional parameters in the converted syntax,
+        where supported.
+
+    .EXAMPLE
+        $commandAst = [System.Management.Automation.Language.Parser]::ParseInput('Should -BeLike "Test*"')
+        Convert-ShouldBeLike -CommandAst $commandAst -Pester6
+
+        This example converts the `Should -BeLike "Test*"` command to Pester 6 syntax.
+
+    .NOTES
+        Pester 5 Syntax:
+            Should -BeLike [[-ActualValue] <Object>] [[-ExpectedValue] <Object>] [[-Because] <string>] [-Not]
+
+            Positional parameters:
+                Position 1: ExpectedValue
+                Position 2: Because
+                Position 3: ActualValue
+
+        Pester 6 Syntax:
+            Should-BeLikeString [[-Actual] <Object>] [-Expected] <String> [-CaseSensitive] [-Because <String>]
+            Should-NotBeLikeString [[-Actual] <Object>] [-Expected] <String> [-CaseSensitive] [-Because <String>]
+
+            Positional parameters:
+                Position 1: Expected
+                Position 2: Actual
+#>
+function Convert-ShouldBeLike
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.CommandAst]
+        $CommandAst,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Pester6')]
+        [System.Management.Automation.SwitchParameter]
+        $Pester6,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UseNamedParameters,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UsePositionalParameters
+    )
+
+    $assertBoundParameterParameters = @{
+        BoundParameterList     = $PSBoundParameters
+        MutuallyExclusiveList1 = @('UseNamedParameters')
+        MutuallyExclusiveList2 = @('UsePositionalParameters')
+    }
+
+    Assert-BoundParameter @assertBoundParameterParameters
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ParsingCommandAst -f $CommandAst.Extent.Text)
+
+    # Determine if the command is negated
+    $isNegated = Test-PesterCommandNegated -CommandAst $CommandAst
+
+    $sourceSyntaxVersion = Get-PesterCommandSyntaxVersion -CommandAst $CommandAst
+
+    # Parse the command elements and convert them to Pester 6 syntax
+    if ($PSCmdlet.ParameterSetName -eq 'Pester6')
+    {
+        Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertingFromTo -f $sourceSyntaxVersion, '6')
+
+        # Add the correct Pester command based on negation
+        if ($isNegated)
+        {
+            $newExtentText = 'Should-NotBeLikeString'
+        }
+        else
+        {
+            $newExtentText = 'Should-BeLikeString'
+        }
+
+        $getPesterCommandParameterParameters = @{
+            CommandAst          = $CommandAst
+            CommandName         = 'Should'
+            IgnoreParameter     = @(
+                'BeLike'
+                'Not'
+            )
+            PositionalParameter = @(
+                'ExpectedValue'
+                'Because'
+                'ActualValue'
+            )
+        }
+
+        $commandParameters = Get-PesterCommandParameter @getPesterCommandParameterParameters
+
+        # Parameter 'Because' is only supported as named parameter in Pester 6 syntax.
+        if ($commandParameters.Because)
+        {
+            $commandParameters.Because.Positional = $false
+        }
+
+        # Determine if named or positional parameters should be forcibly used
+        if ($UseNamedParameters.IsPresent)
+        {
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+        }
+        elseif ($UsePositionalParameters.IsPresent)
+        {
+            # First set all to named parameters
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+
+            <#
+                If a previous positional parameter is missing then the ones behind
+                it cannot be set to positional.
+            #>
+            if ($commandParameters.ExpectedValue)
+            {
+                $commandParameters.ExpectedValue.Positional = $true
+
+                if ($commandParameters.ActualValue)
+                {
+                    $commandParameters.ActualValue.Positional = $true
+                }
+            }
+        }
+
+        $newExtentText += $commandParameters.ExpectedValue.Positional ? (' {0}' -f $commandParameters.ExpectedValue.ExtentText) : ''
+        $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
+
+        # Holds the new parameter names so they can be added in alphabetical order.
+        $parameterNames = @()
+
+        foreach ($currentParameter in $commandParameters.Keys)
+        {
+            if ($commandParameters.$currentParameter.Positional -eq $true)
+            {
+                continue
+            }
+
+            switch ($currentParameter)
+            {
+                'ActualValue'
+                {
+                    $parameterNames += @{
+                        Actual = 'ActualValue'
+                    }
+
+                    break
+                }
+
+                'ExpectedValue'
+                {
+                    $parameterNames += @{
+                        Expected = 'ExpectedValue'
+                    }
+
+                    break
+                }
+
+                default
+                {
+                    $parameterNames += @{
+                        $currentParameter = $currentParameter
+                    }
+
+                    break
+                }
+            }
+        }
+
+        # This handles the named parameters in the command elements, added in alphabetical order.
+        foreach ($currentParameter in $parameterNames.Keys | Sort-Object)
+        {
+            $originalParameterName = $parameterNames.$currentParameter
+
+            $newExtentText += ' -{0} {1}' -f $currentParameter, $commandParameters.$originalParameterName.ExtentText
+        }
+    }
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertedCommand -f $CommandAst.Extent.Text, $newExtentText)
+
+    return $newExtentText
+}

--- a/source/Private/Convert-ShouldBeLikeExactly.ps1
+++ b/source/Private/Convert-ShouldBeLikeExactly.ps1
@@ -1,0 +1,204 @@
+<#
+    .SYNOPSIS
+        Converts a command `Should -BeLikeExactly` to the specified Pester syntax.
+
+    .DESCRIPTION
+        The Convert-ShouldBeLikeExactly function is used to convert a command `Should -BeLikeExactly` to
+        the specified Pester syntax.
+
+    .PARAMETER CommandAst
+        The CommandAst object representing the command to be converted.
+
+    .PARAMETER Pester6
+        Specifies that the command should be converted to Pester version 6 syntax.
+
+    .PARAMETER UseNamedParameters
+        Specifies whether to use named parameters in the converted syntax.
+
+    .PARAMETER UsePositionalParameters
+        Specifies whether to use positional parameters in the converted syntax,
+        where supported.
+
+    .EXAMPLE
+        $commandAst = [System.Management.Automation.Language.Parser]::ParseInput('Should -BeLikeExactly "Test*"')
+        Convert-ShouldBeLikeExactly -CommandAst $commandAst -Pester6
+
+        This example converts the `Should -BeLikeExactly "Test*"` command to Pester 6 syntax.
+
+    .NOTES
+        Pester 5 Syntax:
+            Should -BeLikeExactly [[-ActualValue] <Object>] [[-ExpectedValue] <Object>] [[-Because] <string>] [-Not]
+
+            Positional parameters:
+                Position 1: ExpectedValue
+                Position 2: Because
+                Position 3: ActualValue
+
+        Pester 6 Syntax:
+            Should-BeLikeString [[-Actual] <Object>] [-Expected] <String> [-CaseSensitive] [-Because <String>]
+            Should-NotBeLikeString [[-Actual] <Object>] [-Expected] <String> [-CaseSensitive] [-Because <String>]
+
+            Positional parameters:
+                Position 1: Expected
+                Position 2: Actual
+#>
+function Convert-ShouldBeLikeExactly
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.CommandAst]
+        $CommandAst,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Pester6')]
+        [System.Management.Automation.SwitchParameter]
+        $Pester6,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UseNamedParameters,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UsePositionalParameters
+    )
+
+    $assertBoundParameterParameters = @{
+        BoundParameterList     = $PSBoundParameters
+        MutuallyExclusiveList1 = @('UseNamedParameters')
+        MutuallyExclusiveList2 = @('UsePositionalParameters')
+    }
+
+    Assert-BoundParameter @assertBoundParameterParameters
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ParsingCommandAst -f $CommandAst.Extent.Text)
+
+    # Determine if the command is negated
+    $isNegated = Test-PesterCommandNegated -CommandAst $CommandAst
+
+    $sourceSyntaxVersion = Get-PesterCommandSyntaxVersion -CommandAst $CommandAst
+
+    # Parse the command elements and convert them to Pester 6 syntax
+    if ($PSCmdlet.ParameterSetName -eq 'Pester6')
+    {
+        Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertingFromTo -f $sourceSyntaxVersion, '6')
+
+        # Add the correct Pester command based on negation
+        if ($isNegated)
+        {
+            $newExtentText = 'Should-NotBeLikeString'
+        }
+        else
+        {
+            $newExtentText = 'Should-BeLikeString'
+        }
+
+        # Always add the `-CaseSensitive` parameter since MatchExactly was case-sensitive.
+        $newExtentText += ' -CaseSensitive'
+
+        $getPesterCommandParameterParameters = @{
+            CommandAst          = $CommandAst
+            CommandName         = 'Should'
+            IgnoreParameter     = @(
+                'BeLikeExactly'
+                'Not'
+            )
+            PositionalParameter = @(
+                'ExpectedValue'
+                'Because'
+                'ActualValue'
+            )
+        }
+
+        $commandParameters = Get-PesterCommandParameter @getPesterCommandParameterParameters
+
+        # Parameter 'Because' is only supported as named parameter in Pester 6 syntax.
+        if ($commandParameters.Because)
+        {
+            $commandParameters.Because.Positional = $false
+        }
+
+        # Determine if named or positional parameters should be forcibly used
+        if ($UseNamedParameters.IsPresent)
+        {
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+        }
+        elseif ($UsePositionalParameters.IsPresent)
+        {
+            # First set all to named parameters
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+
+            <#
+                If a previous positional parameter is missing then the ones behind
+                it cannot be set to positional.
+            #>
+            if ($commandParameters.ExpectedValue)
+            {
+                $commandParameters.ExpectedValue.Positional = $true
+
+                if ($commandParameters.ActualValue)
+                {
+                    $commandParameters.ActualValue.Positional = $true
+                }
+            }
+        }
+
+        $newExtentText += $commandParameters.ExpectedValue.Positional ? (' {0}' -f $commandParameters.ExpectedValue.ExtentText) : ''
+        $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
+
+        # Holds the new parameter names so they can be added in alphabetical order.
+        $parameterNames = @()
+
+        foreach ($currentParameter in $commandParameters.Keys)
+        {
+            if ($commandParameters.$currentParameter.Positional -eq $true)
+            {
+                continue
+            }
+
+            switch ($currentParameter)
+            {
+                'ActualValue'
+                {
+                    $parameterNames += @{
+                        Actual = 'ActualValue'
+                    }
+
+                    break
+                }
+
+                'ExpectedValue'
+                {
+                    $parameterNames += @{
+                        Expected = 'ExpectedValue'
+                    }
+
+                    break
+                }
+
+                default
+                {
+                    $parameterNames += @{
+                        $currentParameter = $currentParameter
+                    }
+
+                    break
+                }
+            }
+        }
+
+        # This handles the named parameters in the command elements, added in alphabetical order.
+        foreach ($currentParameter in $parameterNames.Keys | Sort-Object)
+        {
+            $originalParameterName = $parameterNames.$currentParameter
+
+            $newExtentText += ' -{0} {1}' -f $currentParameter, $commandParameters.$originalParameterName.ExtentText
+        }
+    }
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertedCommand -f $CommandAst.Extent.Text, $newExtentText)
+
+    return $newExtentText
+}

--- a/source/WikiSource/Pester_v5_Conversion.md
+++ b/source/WikiSource/Pester_v5_Conversion.md
@@ -24,6 +24,8 @@ BeGreaterOrEqual | `Should-BeGreaterThanOrEqual` | `Should-BeLessThanOrEqual` |
 BeGreaterThan | `Should-BeGreaterThan` | `Should-BeLessThan` | -
 BeLessOrEqual | `Should-BeLessThanOrEqual` | `Should-BeGreaterThanOrEqual` | -
 BeLessThan | `Should-BeLessThan` | `Should-BeGreaterThan` | -
+BeLike | `Should-BeLikeString` | `Should-NotBeLikeString` | -
+BeLikeExactly | `Should-BeLikeString -CaseSensitive` | `Should-NotBeLikeString -CaseSensitive` | -
 BeNullOrEmpty | `Should-BeFalsy` | `Should-BeTruthy` | See 2)
 BeOfType | `Should-HaveType` | `Should-NotHaveType` | -
 BeTrue | `Should-BeTrue` | `Should-BeFalse` | -

--- a/tests/ShouldBe.v5.mocktest.ps1
+++ b/tests/ShouldBe.v5.mocktest.ps1
@@ -1,0 +1,255 @@
+<#
+    Tests Pester 5 syntax: Should [[-ActualValue] <Object>] [-Be] [-Not] [-ExpectedValue <Object>] [-Because <Object>]
+#>
+Describe 'ShouldBe' {
+    # It 'Should be true' {
+    #     $true | Should -Be $true
+    # }
+
+    # It 'Should be false' {
+    #     $false | Should -Be $false
+    # }
+
+    It 'Should be true' {
+        $true | Should -BeTrue
+    }
+
+    It 'Should be false' {
+        $false | Should -BeFalse
+    }
+
+    It 'Should be false' {
+        Should -BeFalse 'because mock should test correct value' $false
+    }
+
+    It 'Should be false' {
+        Should -BeFalse -Because 'because mock should test correct value' $false
+    }
+
+    It 'Should be false' {
+        Should -BeFalse $false -Because 'because mock should test correct value'
+    }
+
+    It 'Should be false' {
+        Should -BeFalse -Actual $false 'because mock should test correct value'
+    }
+
+    It 'Should be false' {
+        Should -BeFalse 'because mock should test correct value' -Actual $false
+    }
+
+    # It 'Should be true' {
+    #     $false | Should -Not -Be $true
+    # }
+
+    # It 'Should be false' {
+    #     $true | Should -Be $false -Not
+    # }
+
+    # It 'Should be true' {
+    #     $false | Should -Not:$true -Be $true
+    # }
+
+    It 'Should be true' {
+        $false | Should -Not:$true -BeTrue
+    }
+
+    It 'Should be false' {
+        $false | Should -Not:$false -BeFalse
+    }
+
+    # It 'Should be true' {
+    #     Should -ActualValue $true -Be $true
+    # }
+
+    It 'Should be true' {
+        Should -ActualValue $true -BeTrue
+    }
+
+    # It 'Should be false' {
+    #     Should -Not -ActualValue $true -Be $false
+    # }
+
+    # It 'Should be false' {
+    #     Should -Be $false -ActualValue $true -Not
+    # }
+
+    It 'Should be false' {
+        Should -ActualValue $true -BeFalse -Not
+    }
+
+    It 'Should be false' {
+        Should -ActualValue $true -Be -Not -ExpectedValue $false
+    }
+
+    # It 'Should be false' {
+    #     Should -ActualValue $true -Be -Not $false
+    # }
+
+    # This is not allowed syntax
+    # It 'Should be true' {
+    #     Should $true -Be $true
+    # }
+
+    # This is not allowed syntax
+    # It 'Should be true' {
+    #     Should $true -BeTrue
+    # }
+
+    It 'Should be false' {
+        Should -Be $false 'mock should test correct value' $false
+    }
+
+    It 'Should be false (with -Because)' {
+        Should -Be $false -Because 'mock should test correct value' $false
+    }
+
+    It 'Should be false' {
+        Should $false 'mock should test correct value' $false -Be
+    }
+
+    It 'Should be false' {
+        Should -BeExactly 'ExpectedString' 'mock should test correct value' 'ExpectedString'
+    }
+
+    It 'Should be false' {
+        Should -Be 'ExpectedString' 'mock should test correct value' 'ExpectedString'
+    }
+
+    # This is not allowed syntax, it generates an array of values 'a' and 'b' that cannot be compared to a single value
+    # It 'Should be false' {
+    #     Should -Be @('a', 'b') 'because mock should test correct value' 'a' 'b'
+    # }
+
+    It 'Should be true (v6)' {
+        Should-Be 'a' 'a'
+    }
+
+    It 'Should be true (v6)' {
+        Should-Be 'a' 'a' -Because 'a should equal a'
+    }
+
+    It 'Should be true (v6)' {
+        Should-Be 'a' -Because 'a should equal a' 'a'
+    }
+
+    It 'Should be true (v6)' {
+        Should-Be -Because 'a should equal a' 'a' 'a'
+    }
+
+    It 'Should throw' {
+        { throw 'hej' } | Should -Throw
+    }
+
+    It 'Should throw' {
+        { throw 'hej' } | Should -Throw -Because 'Expected to throw'
+    }
+
+    It 'Should throw' {
+        { throw 'hej' } | Should -Throw -Because 'Expected to throw' -ErrorId 'hej'
+    }
+
+    It 'Should throw' {
+        { throw 'hej' } | Should -Throw -Because 'Expected to throw' -ErrorId 'hej' -ExpectedMessage 'hej'
+    }
+
+    It 'Should throw' {
+        { throw 'hej' } | Should -Throw -Because 'Expected to throw' -ErrorId 'hej' -ExpectedMessage 'hej' -ExceptionType ([Exception])
+    }
+
+    It 'Should throw' {
+        {
+            Write-Error -Message 'MockErrorMessage' -ErrorId 'MockErrorId' -Category 'InvalidOperation' -TargetObject 'MockTargetObject' -ErrorAction 'Stop'
+        } | Should -Throw 'MockErrorMessage'
+    }
+
+    It 'Should throw' {
+        {
+            Write-Error -Message 'MockErrorMessage' -ErrorId 'MockErrorId' -Category 'InvalidOperation' -TargetObject 'MockTargetObject' -ErrorAction 'Stop'
+        } | Should -Throw 'MockErrorMessage' 'MockErrorId'
+    }
+
+    It 'Should throw' {
+        {
+            Write-Error -Message 'MockErrorMessage' -ErrorId 'MockErrorId' -Category 'InvalidOperation' -TargetObject 'MockTargetObject' -ErrorAction 'Stop'
+        } | Should -Throw 'MockErrorMessage' 'MockErrorId' ([System.Exception])
+    }
+
+    It 'Should throw' {
+        {
+            Write-Error -Message 'MockErrorMessage' -ErrorId 'MockErrorId' -Category 'InvalidOperation' -TargetObject 'MockTargetObject' -ErrorAction 'Stop'
+        } | Should -Throw 'MockErrorMessage' 'MockErrorId' ([System.Exception]) 'BecauseString'
+    }
+
+
+    # It 'Should throw' {
+    #     { 1+1 } | Should -Throw -Because 'Expected to throw' -ErrorId 'hej' -ExpectedMessage 'hej' -ExceptionType ([Exception]) -Not
+    # }
+
+    It 'Should throw' {
+        $errorPassThru = ({ throw 'hej' } | Should -Throw -Because 'Expected to throw' -ErrorId 'hej' -ExpectedMessage 'hej' -ExceptionType ([Exception]) -PassThru)
+        $errorPassThru.Exception.Message | Should -Be 'hej'
+    }
+
+    It 'Should throw' {
+        { throw 'hej' } | Should -Throw 'hej'
+    }
+
+    It 'Should throw with actual value' {
+         Should -Throw 'hej' -ActualValue { throw 'hej' }
+    }
+
+    It 'Should throw using only positional parameters' {
+        {
+            Write-Error -Message 'MockErrorMessage' -ErrorId 'MockErrorId' -Category 'InvalidOperation' -TargetObject 'MockTargetObject' -ErrorAction 'Stop'
+        } | Should -Throw 'MockErrorMessage' 'MockErrorId' ([Microsoft.PowerShell.Commands.WriteErrorException]) 'MockBecauseString'
+    }
+
+    # Not possible without curly braces (script block)
+    # It 'Should throw using only named parameters' {
+    #     (1 + 1) | Should -Not -Throw -ExpectedMessage 'MockErrorMessage' -ErrorId 'MockErrorId' -ExceptionType ([Microsoft.PowerShell.Commands.WriteErrorException]) -Because 'MockBecauseString'
+    # }
+
+    # Not supported in Pester 5
+    # It 'Should BeOfType' {
+    #     Should [System.String] $null 'ActualValue' -BeOfType
+    # }
+
+    # Not supported in Pester 5
+    # It 'Should BeOfType' {
+    #     Should [System.String] 'ActualValue' 'mock must have correct type' -BeOfType
+    # }
+
+    It 'Should BeOfType' {
+        Should [System.String] 'mock must have correct type' -ActualValue 'ActualValue' -BeOfType
+    }
+
+    It 'Should BeOfType' {
+        'ActualValue' | Should [System.String] 'mock must have correct type' -BeOfType
+    }
+
+    It 'Should Match' {
+         Should -Match '^\[.+\]$' 'must match regex' '[Actual]'
+    }
+
+    It 'Should MatchExactly' {
+         Should -MatchExactly '^\[.+\]$' 'must match regex' '[Actual]'
+    }
+
+    It 'Should Contain' {
+        @('a', 'Expected') | Should -Contain 'Expected' 'must contain correct value'
+    }
+
+    # This does not work. It is not possible to use the -ActualValue positional parameter with the -Contain parameter
+    # It 'Should Contain' {
+    #     Should -Contain 'Expected' 'must contain correct value' @('a', 'Expected')
+    # }
+
+    It 'Should BeGreaterThan' {
+        Should -BeGreaterThan 2 'must be higher' 3
+    }
+
+    It 'Should BeGreaterThan' {
+        Should -BeLike 'ExpectedString*' 'must be part of the string' 'ExpectedStringActualString'
+    }
+}

--- a/tests/Unit/Private/Convert-ShouldBeLike.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeLike.tests.ps1
@@ -1,0 +1,516 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'PesterConverter'
+
+    Import-Module -Name $script:dscModuleName
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+}
+
+Describe 'Convert-ShouldBeLike' {
+    Context 'When converting Pester 5 syntax to Pester 6 syntax' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues['Convert-ShouldBeLike:Pester6'] = $true
+            }
+        }
+
+        AfterAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues.Remove('Convert-ShouldBeLike:Pester6')
+            }
+        }
+
+        Context 'When the tests are affirming' {
+            It 'Should convert `Should -BeLike ''Test*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike 'Test*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''Test*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLike "ExpectedString*"` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike "ExpectedString*"
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString "ExpectedString*"'
+                }
+            }
+
+            It 'Should convert `Should -BeLike ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLike $anyValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike $anyValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -BeLike ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -BeLike 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -BeLike ''ExpectedString*'' -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike 'ExpectedString*' -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -BeLike -ExpectedValue ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -BeLike -ExpectedValue 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLike -ActualValue ''ActualString'' -ExpectedValue ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike -ActualValue 'ActualString' -ExpectedValue 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLike -ExpectedValue ''ExpectedString*'' -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike -ExpectedValue 'ExpectedString*' -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue ''ExpectedString*'' -BeLike -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 'ExpectedString*' -BeLike -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue ''ExpectedString*'' -ActualValue ''ActualString'' -BeLike` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 'ExpectedString*' -ActualValue 'ActualString' -BeLike
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -Not:$false -BeLike ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$false -BeLike 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLike (Get-Something)` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        function Get-Something { return 'ExpectedString*' }
+                        'ExpectedString*' | Should -BeLike (Get-Something)
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString (Get-Something)'
+                }
+            }
+
+            It 'Should convert `Should -BeLike ''ExpectedString*'' -Because ''mock should test correct value'' ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike 'ExpectedString*' -Because 'mock should test correct value' 'ActualString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''ExpectedString*'' ''ActualString*'' -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should -BeLike ''ExpectedString*'' ''mock should test correct value'' ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike 'ExpectedString*' 'mock should test correct value' 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''ExpectedString*'' ''ActualString'' -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should ''ExpectedString*'' ''mock should test correct value'' ''ActualString'' -BeLike` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should 'ExpectedString*' 'mock should test correct value' 'ActualString' -BeLike
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''ExpectedString*'' ''ActualString'' -Because ''mock should test correct value'''
+                }
+            }
+        }
+
+        Context 'When the tests are negated' {
+            It 'Should convert `Should -Not -BeLike ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLike 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLike ''Test*'' -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike 'Test*' -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString ''Test*'''
+                }
+            }
+
+            It 'Should convert `Should -Not -BeLike "ExpectedString*"` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLike "ExpectedString*"
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString "ExpectedString*"'
+                }
+            }
+
+            It 'Should convert `Should -Not -BeLike $anyValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLike $anyValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -BeLike $anyValue -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike $anyValue -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -Not:$true -BeLike ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$true -BeLike 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -Not -ActualValue ''ActualString'' -BeLike ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -ActualValue 'ActualString' -BeLike 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -Not -BeLike ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -Not -BeLike 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -BeLike ''ExpectedString*'' -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -BeLike 'ExpectedString*' -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -BeLike ''ExpectedString*'' -ActualValue ''ActualString'' -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike 'ExpectedString*' -ActualValue 'ActualString' -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -BeLike ''ExpectedString*'' -Not -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike 'ExpectedString*' -Not -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -Not -BeLike ''ExpectedString*'' -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLike 'ExpectedString*' -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -BeLike -Not -ExpectedValue ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -BeLike -Not -ExpectedValue 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -Not -BeLike -ExpectedValue ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -Not -BeLike -ExpectedValue 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -BeLike -ExpectedValue ''ExpectedString*'' -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -BeLike -ExpectedValue 'ExpectedString*' -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+        }
+
+        Context 'When tests should always use named parameters' {
+            It 'Should convert `Should -BeLike ''ExpectedString*'' -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLike 'ExpectedString*' -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5 -UseNamedParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+        }
+
+        Context 'When tests should always use positional parameters' {
+            Context 'When the tests are affirming' {
+                It 'Should convert `Should -BeLike ''ExpectedString*'' -ActualValue ''ActualString''` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLike 'ExpectedString*' -ActualValue 'ActualString'
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''ExpectedString*'' ''ActualString'''
+                    }
+                }
+
+                It 'Should convert `Should -BeLike ''ExpectedString*'' -ActualValue ''ActualString'' -Because "this must return true"` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLike 'ExpectedString*' -ActualValue 'ActualString' -Because "this must return true"
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''ExpectedString*'' ''ActualString'' -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -BeLike ''ExpectedString*'' -Because "this must return true" -ActualValue ''ActualString''` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLike 'ExpectedString*' -Because "this must return true" -ActualValue 'ActualString'
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''ExpectedString*'' ''ActualString'' -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -Because "this must return true" -ActualValue ''ActualString'' -BeLike ''ExpectedString*''` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -Because "this must return true" -ActualValue 'ActualString' -BeLike 'ExpectedString*'
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLikeString ''ExpectedString*'' ''ActualString'' -Because "this must return true"'
+                    }
+                }
+            }
+
+            Context 'When the tests are negated' {
+                It 'Should convert `Should -BeLike ''ExpectedString*'' -ActualValue ''ActualString'' -Because "this must return true" -Not` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLike 'ExpectedString*' -ActualValue 'ActualString' -Because "this must return true" -Not
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLike -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString ''ExpectedString*'' ''ActualString'' -Because "this must return true"'
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/Unit/Private/Convert-ShouldBeLikeExactly.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeLikeExactly.tests.ps1
@@ -1,0 +1,516 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'PesterConverter'
+
+    Import-Module -Name $script:dscModuleName
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+}
+
+Describe 'Convert-ShouldBeLikeExactly' {
+    Context 'When converting Pester 5 syntax to Pester 6 syntax' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues['Convert-ShouldBeLikeExactly:Pester6'] = $true
+            }
+        }
+
+        AfterAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues.Remove('Convert-ShouldBeLikeExactly:Pester6')
+            }
+        }
+
+        Context 'When the tests are affirming' {
+            It 'Should convert `Should -BeLikeExactly ''Test*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly 'Test*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''Test*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly "ExpectedString*"` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly "ExpectedString*"
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive "ExpectedString*"'
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly $anyValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly $anyValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -BeLikeExactly ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -BeLikeExactly 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly ''ExpectedString*'' -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly 'ExpectedString*' -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -BeLikeExactly -ExpectedValue ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -BeLikeExactly -ExpectedValue 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly -ActualValue ''ActualString'' -ExpectedValue ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly -ActualValue 'ActualString' -ExpectedValue 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly -ExpectedValue ''ExpectedString*'' -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly -ExpectedValue 'ExpectedString*' -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue ''ExpectedString*'' -BeLikeExactly -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 'ExpectedString*' -BeLikeExactly -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -ExpectedValue ''ExpectedString*'' -ActualValue ''ActualString'' -BeLikeExactly` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ExpectedValue 'ExpectedString*' -ActualValue 'ActualString' -BeLikeExactly
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -Not:$false -BeLikeExactly ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$false -BeLikeExactly 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly (Get-Something)` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        function Get-Something { return 'ExpectedString*' }
+                        'ExpectedString*' | Should -BeLikeExactly (Get-Something)
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive (Get-Something)'
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly ''ExpectedString*'' -Because ''mock should test correct value'' ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly 'ExpectedString*' -Because 'mock should test correct value' 'ActualString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''ExpectedString*'' ''ActualString*'' -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly ''ExpectedString*'' ''mock should test correct value'' ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly 'ExpectedString*' 'mock should test correct value' 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''ExpectedString*'' ''ActualString'' -Because ''mock should test correct value'''
+                }
+            }
+
+            It 'Should convert `Should ''ExpectedString*'' ''mock should test correct value'' ''ActualString'' -BeLikeExactly` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should 'ExpectedString*' 'mock should test correct value' 'ActualString' -BeLikeExactly
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''ExpectedString*'' ''ActualString'' -Because ''mock should test correct value'''
+                }
+            }
+        }
+
+        Context 'When the tests are negated' {
+            It 'Should convert `Should -Not -BeLikeExactly ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLikeExactly 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly ''Test*'' -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly 'Test*' -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive ''Test*'''
+                }
+            }
+
+            It 'Should convert `Should -Not -BeLikeExactly "ExpectedString*"` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLikeExactly "ExpectedString*"
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive "ExpectedString*"'
+                }
+            }
+
+            It 'Should convert `Should -Not -BeLikeExactly $anyValue` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLikeExactly $anyValue
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly $anyValue -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly $anyValue -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive $anyValue'
+                }
+            }
+
+            It 'Should convert `Should -Not:$true -BeLikeExactly ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        $false | Should -Not:$true -BeLikeExactly 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -Not -ActualValue ''ActualString'' -BeLikeExactly ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -ActualValue 'ActualString' -BeLikeExactly 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -Not -BeLikeExactly ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -Not -BeLikeExactly 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -BeLikeExactly ''ExpectedString*'' -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -BeLikeExactly 'ExpectedString*' -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly ''ExpectedString*'' -ActualValue ''ActualString'' -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly 'ExpectedString*' -ActualValue 'ActualString' -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -BeLikeExactly ''ExpectedString*'' -Not -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly 'ExpectedString*' -Not -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -Not -BeLikeExactly ''ExpectedString*'' -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -Not -BeLikeExactly 'ExpectedString*' -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive ''ExpectedString*'' -Actual ''ActualString'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -BeLikeExactly -Not -ExpectedValue ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -BeLikeExactly -Not -ExpectedValue 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -Not -BeLikeExactly -ExpectedValue ''ExpectedString*''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -Not -BeLikeExactly -ExpectedValue 'ExpectedString*'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+
+            It 'Should convert `Should -ActualValue ''ActualString'' -BeLikeExactly -ExpectedValue ''ExpectedString*'' -Not` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -ActualValue 'ActualString' -BeLikeExactly -ExpectedValue 'ExpectedString*' -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5
+
+                    $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+        }
+
+        Context 'When tests should always use named parameters' {
+            It 'Should convert `Should -BeLikeExactly ''ExpectedString*'' -ActualValue ''ActualString''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAstPester5 = {
+                        Should -BeLikeExactly 'ExpectedString*' -ActualValue 'ActualString'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5 -UseNamedParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive -Actual ''ActualString'' -Expected ''ExpectedString*'''
+                }
+            }
+        }
+
+        Context 'When tests should always use positional parameters' {
+            Context 'When the tests are affirming' {
+                It 'Should convert `Should -BeLikeExactly ''ExpectedString*'' -ActualValue ''ActualString''` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLikeExactly 'ExpectedString*' -ActualValue 'ActualString'
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''ExpectedString*'' ''ActualString'''
+                    }
+                }
+
+                It 'Should convert `Should -BeLikeExactly ''ExpectedString*'' -ActualValue ''ActualString'' -Because "this must return true"` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLikeExactly 'ExpectedString*' -ActualValue 'ActualString' -Because "this must return true"
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''ExpectedString*'' ''ActualString'' -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -BeLikeExactly ''ExpectedString*'' -Because "this must return true" -ActualValue ''ActualString''` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLikeExactly 'ExpectedString*' -Because "this must return true" -ActualValue 'ActualString'
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''ExpectedString*'' ''ActualString'' -Because "this must return true"'
+                    }
+                }
+
+                It 'Should convert `Should -Because "this must return true" -ActualValue ''ActualString'' -BeLikeExactly ''ExpectedString*''` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -Because "this must return true" -ActualValue 'ActualString' -BeLikeExactly 'ExpectedString*'
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-BeLikeString -CaseSensitive ''ExpectedString*'' ''ActualString'' -Because "this must return true"'
+                    }
+                }
+            }
+
+            Context 'When the tests are negated' {
+                It 'Should convert `Should -BeLikeExactly ''ExpectedString*'' -ActualValue ''ActualString'' -Because "this must return true" -Not` correctly' {
+                    InModuleScope -ScriptBlock {
+                        $mockCommandAstPester5 = {
+                            Should -BeLikeExactly 'ExpectedString*' -ActualValue 'ActualString' -Because "this must return true" -Not
+                        }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                        $result = Convert-ShouldBeLikeExactly -CommandAst $mockCommandAstPester5 -UsePositionalParameters
+
+                        $result | Should-BeString -CaseSensitive 'Should-NotBeLikeString -CaseSensitive ''ExpectedString*'' ''ActualString'' -Because "this must return true"'
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### Pull Request (PR) description
- Add support for Should operators:
  - BeLike
  - BeLikeExactly

#### This Pull Request (PR) fixes the following issues
- Fixes #12
- Fixes #13

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Documentation added/updated in README.md and source/WikiSource.
- [x] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where applicable). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/PesterConverter/25)
<!-- Reviewable:end -->
