### PR TITLE
Add support for `Should -HaveCount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
       - BeOfType
       - BeTrue
       - Contain
+      - HaveCount
       - Invoke
       - Match
       - MatchExactly

--- a/source/Private/Convert-ShouldBe.ps1
+++ b/source/Private/Convert-ShouldBe.ps1
@@ -140,7 +140,7 @@ function Convert-ShouldBe
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -153,27 +153,21 @@ function Convert-ShouldBe
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'ExpectedValue'
                 {
-                    $parameterNames += @{
-                        Expected = 'ExpectedValue'
-                    }
+                    $parameterNames.Expected = 'ExpectedValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeExactly.ps1
+++ b/source/Private/Convert-ShouldBeExactly.ps1
@@ -143,7 +143,7 @@ function Convert-ShouldBeExactly
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -156,27 +156,21 @@ function Convert-ShouldBeExactly
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'ExpectedValue'
                 {
-                    $parameterNames += @{
-                        Expected = 'ExpectedValue'
-                    }
+                    $parameterNames.Expected = 'ExpectedValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeFalse.ps1
+++ b/source/Private/Convert-ShouldBeFalse.ps1
@@ -140,7 +140,7 @@ function Convert-ShouldBeFalse
         }
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -153,18 +153,14 @@ function Convert-ShouldBeFalse
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeGreaterOrEqual.ps1
+++ b/source/Private/Convert-ShouldBeGreaterOrEqual.ps1
@@ -140,7 +140,7 @@ function Convert-ShouldBeGreaterOrEqual
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -153,27 +153,21 @@ function Convert-ShouldBeGreaterOrEqual
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'ExpectedValue'
                 {
-                    $parameterNames += @{
-                        Expected = 'ExpectedValue'
-                    }
+                    $parameterNames.Expected = 'ExpectedValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeGreaterThan.ps1
+++ b/source/Private/Convert-ShouldBeGreaterThan.ps1
@@ -148,7 +148,7 @@ function Convert-ShouldBeGreaterThan
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -161,27 +161,21 @@ function Convert-ShouldBeGreaterThan
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'ExpectedValue'
                 {
-                    $parameterNames += @{
-                        Expected = 'ExpectedValue'
-                    }
+                    $parameterNames.Expected = 'ExpectedValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeIn.ps1
+++ b/source/Private/Convert-ShouldBeIn.ps1
@@ -174,7 +174,7 @@ function Convert-ShouldBeIn
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -192,27 +192,21 @@ function Convert-ShouldBeIn
                         continue
                     }
 
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'ExpectedValue'
                 {
-                    $parameterNames += @{
-                        Expected = 'ExpectedValue'
-                    }
+                    $parameterNames.Expected = 'ExpectedValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeLessOrEqual.ps1
+++ b/source/Private/Convert-ShouldBeLessOrEqual.ps1
@@ -140,7 +140,7 @@ function Convert-ShouldBeLessOrEqual
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -153,27 +153,21 @@ function Convert-ShouldBeLessOrEqual
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'ExpectedValue'
                 {
-                    $parameterNames += @{
-                        Expected = 'ExpectedValue'
-                    }
+                    $parameterNames.Expected = 'ExpectedValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeLessThan.ps1
+++ b/source/Private/Convert-ShouldBeLessThan.ps1
@@ -148,7 +148,7 @@ function Convert-ShouldBeLessThan
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -161,27 +161,21 @@ function Convert-ShouldBeLessThan
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'ExpectedValue'
                 {
-                    $parameterNames += @{
-                        Expected = 'ExpectedValue'
-                    }
+                    $parameterNames.Expected = 'ExpectedValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeLike.ps1
+++ b/source/Private/Convert-ShouldBeLike.ps1
@@ -139,7 +139,7 @@ function Convert-ShouldBeLike
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -152,27 +152,21 @@ function Convert-ShouldBeLike
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'ExpectedValue'
                 {
-                    $parameterNames += @{
-                        Expected = 'ExpectedValue'
-                    }
+                    $parameterNames.Expected = 'ExpectedValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeLikeExactly.ps1
+++ b/source/Private/Convert-ShouldBeLikeExactly.ps1
@@ -142,7 +142,7 @@ function Convert-ShouldBeLikeExactly
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -155,27 +155,21 @@ function Convert-ShouldBeLikeExactly
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'ExpectedValue'
                 {
-                    $parameterNames += @{
-                        Expected = 'ExpectedValue'
-                    }
+                    $parameterNames.Expected = 'ExpectedValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeNullOrEmpty.ps1
+++ b/source/Private/Convert-ShouldBeNullOrEmpty.ps1
@@ -148,7 +148,7 @@ function Convert-ShouldBeNullOrEmpty
         }
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -161,18 +161,14 @@ function Convert-ShouldBeNullOrEmpty
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeOfType.ps1
+++ b/source/Private/Convert-ShouldBeOfType.ps1
@@ -162,7 +162,7 @@ function Convert-ShouldBeOfType
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -175,27 +175,21 @@ function Convert-ShouldBeOfType
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'ExpectedType'
                 {
-                    $parameterNames += @{
-                        Expected = 'ExpectedType'
-                    }
+                    $parameterNames.Expected = 'ExpectedType'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldBeTrue.ps1
+++ b/source/Private/Convert-ShouldBeTrue.ps1
@@ -143,7 +143,7 @@ function Convert-ShouldBeTrue
         }
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -156,18 +156,14 @@ function Convert-ShouldBeTrue
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldContain.ps1
+++ b/source/Private/Convert-ShouldContain.ps1
@@ -140,7 +140,7 @@ function Convert-ShouldContain
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -153,27 +153,21 @@ function Convert-ShouldContain
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'ExpectedValue'
                 {
-                    $parameterNames += @{
-                        Expected = 'ExpectedValue'
-                    }
+                    $parameterNames.Expected = 'ExpectedValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldHaveCount.ps1
+++ b/source/Private/Convert-ShouldHaveCount.ps1
@@ -1,0 +1,205 @@
+<#
+    .SYNOPSIS
+        Converts a command `Should -HaveCount` from Pester v5 to the Pester v6 syntax.
+
+    .DESCRIPTION
+        The Convert-ShouldHaveCount function converts the Pester v5 syntax:
+            Should -HaveCount [[-ActualValue] <Object>] [[-ExpectedValue] <int>] [[-Because] <string>] [-Not]
+        to the Pester v6 syntax:
+            Should-BeCollection [[-Actual] <Object>] [-Because <String>] [-Count <Int32>] [<CommonParameters>]
+
+    .PARAMETER CommandAst
+        The CommandAst object representing the command to be converted.
+
+    .PARAMETER Pester6
+        Specifies that the command should be converted to Pester version 6 syntax.
+
+    .PARAMETER UseNamedParameters
+        Forces the use of named parameters in the converted syntax.
+
+    .PARAMETER UsePositionalParameters
+        Forces the use of positional parameters in the converted syntax.
+
+    .EXAMPLE
+        $commandAst = [System.Management.Automation.Language.Parser]::ParseInput('Should -HaveCount 3')
+        Convert-ShouldHaveCount -CommandAst $commandAst -Pester6
+
+        This example converts the `Should -HaveCount 3` command to Pester 6 syntax.
+
+    .NOTES
+        Pester 5 Syntax:
+            Should -HaveCount [[-ActualValue] <Object>] [[-ExpectedValue] <int>] [[-Because] <string>] [-Not]
+
+            Positional parameters:
+                Position 1: ExpectedValue
+                Position 2: Because
+                Position 3: ActualValue
+
+        Pester 6 Syntax:
+            Should-BeCollection [[-Actual] <Object>] [-Because <String>] [-Count <Int32>] [<CommonParameters>]
+
+            Positional parameters:
+                Position 1: Expected
+                Position 2: Actual
+
+            Negated tests are not supported.
+#>
+function Convert-ShouldHaveCount
+{
+    [CmdletBinding()]
+    [OutputType([System.String])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Management.Automation.Language.CommandAst]
+        $CommandAst,
+
+        [Parameter(Mandatory = $true, ParameterSetName = 'Pester6')]
+        [System.Management.Automation.SwitchParameter]
+        $Pester6,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UseNamedParameters,
+
+        [Parameter()]
+        [System.Management.Automation.SwitchParameter]
+        $UsePositionalParameters
+    )
+
+    $assertBoundParameterParameters = @{
+        BoundParameterList     = $PSBoundParameters
+        MutuallyExclusiveList1 = @('UseNamedParameters')
+        MutuallyExclusiveList2 = @('UsePositionalParameters')
+    }
+
+    Assert-BoundParameter @assertBoundParameterParameters
+
+    Write-Debug -Message ($script:localizedData.Convert_Debug_ParsingCommandAst -f $CommandAst.Extent.Text)
+
+    # Determine if the command is negated
+    $isNegated = Test-PesterCommandNegated -CommandAst $CommandAst
+
+    $sourceSyntaxVersion = Get-PesterCommandSyntaxVersion -CommandAst $CommandAst
+
+    # Parse the command elements and convert them to Pester 6 syntax
+    if ($PSCmdlet.ParameterSetName -eq 'Pester6')
+    {
+        Write-Debug -Message ($script:localizedData.Convert_Debug_ConvertingFromTo -f $sourceSyntaxVersion, '6')
+
+        # Negated tests are not supported.
+        if ($isNegated)
+        {
+            Write-Verbose -Message ($script:localizedData.Convert_HaveCount_Error_NegatedTestsNotSupported -f $CommandAst.Extent.Text)
+
+            return $CommandAst.Extent.Text
+        }
+
+        # Add the correct Pester 6 command name
+        $newExtentText = 'Should-BeCollection'
+
+        $getPesterCommandParameterParameters = @{
+            CommandAst          = $CommandAst
+            CommandName         = 'Should'
+            IgnoreParameter     = @(
+                'HaveCount'
+            )
+            PositionalParameter = @(
+                'ExpectedValue'
+                'Because'
+                'ActualValue'
+            )
+        }
+
+        $commandParameters = Get-PesterCommandParameter @getPesterCommandParameterParameters
+
+        # Parameter 'Because' is only supported as named parameter in Pester 6 syntax.
+        if ($commandParameters.Because)
+        {
+            $commandParameters.Because.Positional = $false
+        }
+
+        <#
+            Parameter 'ExpectedValue' will be set as parameter 'Count' and is only
+            supported as named parameter in Pester 6 syntax.
+        #>
+        if ($commandParameters.ExpectedValue)
+        {
+            $commandParameters.ExpectedValue.Positional = $false
+        }
+
+        # Determine if named or positional parameters should be forcibly used
+        if ($UseNamedParameters.IsPresent)
+        {
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+        }
+        elseif ($UsePositionalParameters.IsPresent)
+        {
+            # First set all to named parameters
+            $commandParameters.Keys.ForEach({ $commandParameters.$_.Positional = $false })
+
+            <#
+                If a previous positional parameter is missing then the ones behind
+                it cannot be set to positional.
+            #>
+            if ($commandParameters.ActualValue)
+            {
+                $commandParameters.ActualValue.Positional = $true
+            }
+        }
+
+        $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
+
+        # Holds the new parameter names so they can be added in alphabetical order.
+        $parameterNames = @{}
+
+        foreach ($currentParameter in $commandParameters.Keys)
+        {
+            if ($commandParameters.$currentParameter.Positional -eq $true)
+            {
+                continue
+            }
+
+            switch ($currentParameter)
+            {
+                'ActualValue'
+                {
+                    $parameterNames.Actual = 'ActualValue'
+
+                    break
+                }
+
+                'ExpectedValue'
+                {
+                    $parameterNames.Count = 'ExpectedValue'
+
+                    break
+                }
+
+                default
+                {
+                    $parameterNames.$currentParameter = $currentParameter
+
+                    break
+                }
+            }
+        }
+
+        # This handles the named parameters in the command elements, added in alphabetical order.
+        foreach ($currentParameter in $parameterNames.Keys | Sort-Object)
+        {
+            $originalParameterName = $parameterNames.$currentParameter
+
+            $newExtentText += ' -{0}' -f $currentParameter
+
+            if ($commandParameters.$originalParameterName.ExtentText)
+            {
+                $newExtentText += ' {0}' -f $commandParameters.$originalParameterName.ExtentText
+            }
+        }
+    }
+
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertedCommand -f $CommandAst.Extent.Text, $newExtentText)
+
+    return $newExtentText
+}

--- a/source/Private/Convert-ShouldHaveCount.ps1
+++ b/source/Private/Convert-ShouldHaveCount.ps1
@@ -75,7 +75,7 @@ function Convert-ShouldHaveCount
 
     Assert-BoundParameter @assertBoundParameterParameters
 
-    Write-Debug -Message ($script:localizedData.Convert_Debug_ParsingCommandAst -f $CommandAst.Extent.Text)
+    Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ParsingCommandAst -f $CommandAst.Extent.Text)
 
     # Determine if the command is negated
     $isNegated = Test-PesterCommandNegated -CommandAst $CommandAst

--- a/source/Private/Convert-ShouldHaveCount.ps1
+++ b/source/Private/Convert-ShouldHaveCount.ps1
@@ -85,7 +85,7 @@ function Convert-ShouldHaveCount
     # Parse the command elements and convert them to Pester 6 syntax
     if ($PSCmdlet.ParameterSetName -eq 'Pester6')
     {
-        Write-Debug -Message ($script:localizedData.Convert_Debug_ConvertingFromTo -f $sourceSyntaxVersion, '6')
+        Write-Debug -Message ($script:localizedData.Convert_Should_Debug_ConvertingFromTo -f $sourceSyntaxVersion, '6')
 
         # Negated tests are not supported.
         if ($isNegated)

--- a/source/Private/Convert-ShouldInvoke.ps1
+++ b/source/Private/Convert-ShouldInvoke.ps1
@@ -144,7 +144,7 @@ function Convert-ShouldInvoke
         $newExtentText += $commandParameters.Times.Positional ? (' {0}' -f $commandParameters.Times.ExtentText) : ''
 
         # Prepare remaining parameters as named parameters in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -159,9 +159,7 @@ function Convert-ShouldInvoke
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldMatch.ps1
+++ b/source/Private/Convert-ShouldMatch.ps1
@@ -140,7 +140,7 @@ function Convert-ShouldMatch
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -153,27 +153,21 @@ function Convert-ShouldMatch
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'RegularExpression'
                 {
-                    $parameterNames += @{
-                        Expected = 'RegularExpression'
-                    }
+                    $parameterNames.Expected = 'RegularExpression'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldMatchExactly.ps1
+++ b/source/Private/Convert-ShouldMatchExactly.ps1
@@ -143,7 +143,7 @@ function Convert-ShouldMatchExactly
         $newExtentText += $commandParameters.ActualValue.Positional ? (' {0}' -f $commandParameters.ActualValue.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -156,27 +156,21 @@ function Convert-ShouldMatchExactly
             {
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        Actual = 'ActualValue'
-                    }
+                    $parameterNames.Actual = 'ActualValue'
 
                     break
                 }
 
                 'RegularExpression'
                 {
-                    $parameterNames += @{
-                        Expected = 'RegularExpression'
-                    }
+                    $parameterNames.Expected = 'RegularExpression'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Private/Convert-ShouldThrow.ps1
+++ b/source/Private/Convert-ShouldThrow.ps1
@@ -177,7 +177,7 @@ function Convert-ShouldThrow
         $newExtentText += $commandParameters.Because.Positional ? (' {0}' -f $commandParameters.Because.ExtentText) : ''
 
         # Holds the new parameter names so they can be added in alphabetical order.
-        $parameterNames = @()
+        $parameterNames = @{}
 
         foreach ($currentParameter in $commandParameters.Keys)
         {
@@ -190,36 +190,28 @@ function Convert-ShouldThrow
             {
                 'ExpectedMessage'
                 {
-                    $parameterNames += @{
-                        ExceptionMessage = 'ExpectedMessage'
-                    }
+                    $parameterNames.ExceptionMessage = 'ExpectedMessage'
 
                     break
                 }
 
                 'ErrorId'
                 {
-                    $parameterNames += @{
-                        FullyQualifiedErrorId = 'ErrorId'
-                    }
+                    $parameterNames.FullyQualifiedErrorId = 'ErrorId'
 
                     break
                 }
 
                 'ActualValue'
                 {
-                    $parameterNames += @{
-                        ScriptBlock = 'ActualValue'
-                    }
+                    $parameterNames.ScriptBlock = 'ActualValue'
 
                     break
                 }
 
                 default
                 {
-                    $parameterNames += @{
-                        $currentParameter = $currentParameter
-                    }
+                    $parameterNames.$currentParameter = $currentParameter
 
                     break
                 }

--- a/source/Public/Convert-PesterSyntax.ps1
+++ b/source/Public/Convert-PesterSyntax.ps1
@@ -399,6 +399,13 @@ function Convert-PesterSyntax
                                 break
                             }
 
+                            'HaveCount'
+                            {
+                                $newExtentText = Convert-ShouldHaveCount -CommandAst $commandAst @convertParameters -ErrorAction 'Stop'
+
+                                break
+                            }
+
                             default
                             {
                                 Write-Warning -Message ($script:localizedData.Convert_PesterSyntax_Warning_UnsupportedCommandOperator -f $operatorName, $commandAst.Extent.Text)

--- a/source/en-US/PesterConverter.strings.psd1
+++ b/source/en-US/PesterConverter.strings.psd1
@@ -39,6 +39,9 @@ ConvertFrom-StringData @'
     Convert_Should_Debug_ConvertingFromTo = Converting from Pester v{0} to Pester v{1} syntax.
     Convert_Should_Debug_ConvertedCommand = Converted the command `{0}` to `{1}`.
 
+    ## Convert-ShouldHaveCount
+    Convert_HaveCount_Error_NegatedTestsNotSupported = Negated tests are not supported: '{0}'.
+
     ## Get-PesterCommandParameter
     Get_PesterCommandParameter_Debug_RetrievingParameters = Retrieving the parameters of the extent: {0}
     Get_PesterCommandParameter_Debug_RetrievingCommandName = Retrieving parameters for the command name: {0}

--- a/tests/Unit/Private/Convert-ShouldHaveCount.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldHaveCount.tests.ps1
@@ -1,0 +1,152 @@
+[System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', '')]
+param ()
+
+BeforeDiscovery {
+    try
+    {
+        if (-not (Get-Module -Name 'DscResource.Test'))
+        {
+            # Assumes dependencies has been resolved, so if this module is not available, run 'noop' task.
+            if (-not (Get-Module -Name 'DscResource.Test' -ListAvailable))
+            {
+                # Redirect all streams to $null, except the error stream (stream 2)
+                & "$PSScriptRoot/../../../build.ps1" -Tasks 'noop' 2>&1 4>&1 5>&1 6>&1 > $null
+            }
+
+            # If the dependencies has not been resolved, this will throw an error.
+            Import-Module -Name 'DscResource.Test' -Force -ErrorAction 'Stop'
+        }
+    }
+    catch [System.IO.FileNotFoundException]
+    {
+        throw 'DscResource.Test module dependency not found. Please run ".\build.ps1 -ResolveDependency -Tasks build" first.'
+    }
+}
+
+BeforeAll {
+    $script:dscModuleName = 'PesterConverter'
+
+    Import-Module -Name $script:dscModuleName
+
+    $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
+    $PSDefaultParameterValues['Should:ModuleName'] = $script:dscModuleName
+}
+
+AfterAll {
+    $PSDefaultParameterValues.Remove('InModuleScope:ModuleName')
+    $PSDefaultParameterValues.Remove('Mock:ModuleName')
+    $PSDefaultParameterValues.Remove('Should:ModuleName')
+
+    # Unload the module being tested so that it doesn't impact any other tests.
+    Get-Module -Name $script:dscModuleName -All | Remove-Module -Force
+}
+
+Describe 'Convert-ShouldHaveCount' {
+    Context 'When converting Pester 5 syntax to Pester 6 syntax' {
+        BeforeAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues['Convert-ShouldHaveCount:Pester6'] = $true
+            }
+        }
+
+        AfterAll {
+            InModuleScope -ScriptBlock {
+                $PSDefaultParameterValues.Remove('Convert-ShouldHaveCount:Pester6')
+            }
+        }
+
+        Context 'When the tests are affirming' {
+            It 'Should convert `Should -HaveCount 3` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAst = {
+                        Should -HaveCount 3
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldHaveCount -CommandAst $mockCommandAst
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeCollection -Count 3'
+                }
+            }
+
+            It 'Should convert `Should -ActualValue $true -HaveCount 5` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAst = {
+                        Should -ActualValue $true -HaveCount 5
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldHaveCount -CommandAst $mockCommandAst
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeCollection -Actual $true -Count 5'
+                }
+            }
+
+            It 'Should convert `Should -HaveCount 5 -ActualValue $true` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAst = {
+                        Should -HaveCount 5 -ActualValue $true
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldHaveCount -CommandAst $mockCommandAst
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeCollection -Actual $true -Count 5'
+                }
+            }
+
+            It 'Should convert `Should -HaveCount 5 -Because ''reason''` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAst = {
+                        Should -HaveCount 5 -Because 'reason'
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldHaveCount -CommandAst $mockCommandAst
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeCollection -Because ''reason'' -Count 5'
+                }
+            }
+        }
+
+        Context 'When the tests are negated' {
+            It 'Should leave negated tests unchanged' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAst = {
+                        Should -HaveCount 3 -Not
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldHaveCount -CommandAst $mockCommandAst
+
+                    # Negated tests are not supported, so the command remains unchanged.
+                    $result | Should-BeString -CaseSensitive $mockCommandAst.Extent.Text
+                }
+            }
+        }
+
+        Context 'When tests should always use named parameters' {
+            It 'Should convert with named parameters for `Should -HaveCount 3 -ActualValue $true` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAst = {
+                        Should -HaveCount 3 -ActualValue $true
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldHaveCount -CommandAst $mockCommandAst -UseNamedParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeCollection -Actual $true -Count 3'
+                }
+            }
+        }
+
+        Context 'When tests should always use positional parameters' {
+            It 'Should convert with positional parameters for `Should -HaveCount 3 -ActualValue $true` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAst = {
+                        Should -HaveCount 3 -ActualValue $true
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldHaveCount -CommandAst $mockCommandAst -UsePositionalParameters
+
+                    $result | Should-BeString -CaseSensitive 'Should-BeCollection $true -Count 3'
+                }
+            }
+        }
+    }
+}

--- a/tests/Unit/Public/Convert-PesterSyntax.tests.ps1
+++ b/tests/Unit/Public/Convert-PesterSyntax.tests.ps1
@@ -1245,6 +1245,64 @@ Describe 'Convert-PesterSyntax' {
             }
         }
 
+        Context 'When converting Should -HaveCount' {
+            BeforeAll {
+                $mockAstExtentText = {
+                    Describe 'Should -HaveCount' {
+                        It 'Should -HaveCount' {
+                            $array | Should -HaveCount 3 -Because 'BecauseString'
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $mockScriptFilePath = Join-Path -Path $TestDrive -ChildPath 'Mock.Tests.ps1'
+
+                Set-Content -Path $mockScriptFilePath -Value $mockAstExtentText -Encoding 'utf8'
+            }
+
+            It 'Should convert the syntax correctly' {
+                $mockExpectedConvertedScript = {
+                    Describe 'Should -HaveCount' {
+                        It 'Should -HaveCount' {
+                            $array | Should-BeCollection -Because 'BecauseString' -Count 3
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+
+            It 'Should convert using named parameters correctly' {
+                $mockExpectedConvertedScript = {
+                    Describe 'Should -HaveCount' {
+                        It 'Should -HaveCount' {
+                            $array | Should-BeCollection -Because 'BecauseString' -Count 3
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -UseNamedParameters -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+
+            It 'Should convert using positional parameters correctly' {
+                $mockExpectedConvertedScript = {
+                    Describe 'Should -HaveCount' {
+                        It 'Should -HaveCount' {
+                            $array | Should-BeCollection -Because 'BecauseString' -Count 3
+                        }
+                    }
+                }.Ast.GetScriptBlock().ToString()
+
+                $result = Convert-PesterSyntax -Path $mockScriptFilePath -UsePositionalParameters -PassThru
+
+                $result | Should-BeString -CaseSensitive -Expected $mockExpectedConvertedScript -TrimWhitespace
+            }
+        }
+
         Context 'When converting several files' {
             BeforeAll {
                 $mockAstExtentText = {


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
<!--
    Replace this comment block with a description of your PR.
    Also, make sure you have updated the CHANGELOG.md, see the
    task list below. An entry in the CHANGELOG.md is mandatory
    for all PRs.
-->

#### This Pull Request (PR) fixes the following issues

- Fixes #19

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md and source/WikiSource.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where applicable). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/PesterConverter/31)
<!-- Reviewable:end -->
