### PR TITLE
fix: handle edge case for recursive Pester commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve bootstrap of tests
 
+### Fixed
+
+- Warns for an unsupported conversion scenario where a Pester command calls
+  another Pester command, for example in a `FilterScript` scriptblock. If
+  such edge case is found it is skipped. Another conversion pass on the
+  converted file will convert those recursively used Pester commands.
+
 ## [0.2.0] - 2026-06-29
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   another Pester command, for example in a `FilterScript` scriptblock. If
   such edge case is found it is skipped. Another conversion pass on the
   converted file will convert those recursively used Pester commands.
+  Fixes [issue #36](https://github.com/viscalyx/PesterConverter/issues/46).
 
 ## [0.2.0] - 2026-06-29
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -34,6 +34,9 @@
     'DscResource.DocGenerator'     = 'latest'
     PlatyPS                        = 'latest'
 
+    # Pester assertions
+    'Viscalyx.Assert'              = 'latest'
+
     # Help with running tests
     'Viscalyx.Common'              = 'latest'
 }

--- a/source/Private/Get-CommandName.ps1
+++ b/source/Private/Get-CommandName.ps1
@@ -3,7 +3,7 @@
         Retrieves the command name from the provided CommandAst.
 
     .DESCRIPTION
-        The Get-CommandNameFromAst function analyzes the CommandAst object to extract
+        The Get-CommandName function analyzes the CommandAst object to extract
         and return the command name. It handles different AST element types to ensure
         the command name is accurately determined.
 

--- a/source/Public/Convert-PesterSyntax.ps1
+++ b/source/Public/Convert-PesterSyntax.ps1
@@ -259,6 +259,19 @@ function Convert-PesterSyntax
 
                     $commandName = Get-CommandName -CommandAst $commandAst -ErrorAction 'Stop'
 
+                    # This checks for edge cases where a Should operator has another Should operator inside it.
+                    $parentAst = @($pesterCommandAst).Where({ -not [object]::ReferenceEquals($_, $commandAst) -and $_.Extent.StartOffset -lt $commandAst.Extent.StartOffset -and $_.Extent.EndOffset -gt $commandAst.Extent.EndOffset }, 'First')
+
+                    $commandAstIsChild = [System.Boolean] $parentAst
+
+                    if ($commandAstIsChild)
+                    {
+                        Write-Warning -Message  ($script:localizedData.Convert_PesterSyntax_Warning_RecursivePesterCommand -f $commandName, $filePath)
+                        Write-Debug -Message ($script:localizedData.Convert_PesterSyntax_Debug_RecursivePesterCommandAst -f $parentAst)
+
+                        continue
+                    }
+
                     switch ($commandName)
                     {
                         'Assert-MockCalled'
@@ -432,7 +445,7 @@ function Convert-PesterSyntax
 
                                     default
                                     {
-                                        Write-Warning -Message ($script:localizedData.Convert_PesterSyntax_Warning_UnsupportedCommandOperator -f $operatorName, $commandAst.Extent.Text)
+                                        Write-Warning -Message ($script:localizedData.Convert_PesterSyntax_Warning_UnsupportedCommandOperator -f $operatorName, $commandAst.Extent.Text, $filePath)
 
                                         $apply = $false
                                     }
@@ -440,7 +453,7 @@ function Convert-PesterSyntax
                             }
                             else
                             {
-                                Write-Warning -Message ($script:localizedData.Convert_PesterSyntax_MissingSupportedCommandOperator -f $commandAst.Extent.Text)
+                                Write-Warning -Message ($script:localizedData.Convert_PesterSyntax_Warning_MissingSupportedCommandOperator -f $commandAst.Extent.Text, $filePath)
                             }
 
                             break
@@ -449,7 +462,7 @@ function Convert-PesterSyntax
 
                     if ($apply)
                     {
-                        # Replace the portion of the script.
+                        # Replace the portion of the script that was converted.
                         $convertedScriptText = $convertedScriptText.Remove($startOffset, $endOffset - $startOffset).Insert($startOffset, $newExtentText)
                     }
                 }

--- a/source/Public/Convert-PesterSyntax.ps1
+++ b/source/Public/Convert-PesterSyntax.ps1
@@ -454,6 +454,8 @@ function Convert-PesterSyntax
                             else
                             {
                                 Write-Warning -Message ($script:localizedData.Convert_PesterSyntax_Warning_MissingSupportedCommandOperator -f $commandAst.Extent.Text, $filePath)
+
+                                $apply = $false
                             }
 
                             break

--- a/source/en-US/PesterConverter.strings.psd1
+++ b/source/en-US/PesterConverter.strings.psd1
@@ -29,12 +29,12 @@ ConvertFrom-StringData @'
     Convert_PesterSyntax_Debug_ScriptBlockAst = Parsing the script block AST: {0}
     Convert_PesterSyntax_Debug_FoundShouldCommand = Found {0} `Should` command(s) in file '{1}'.
     Convert_PesterSyntax_Warning_UnsupportedCommandOperator = Unsupported command operator '{0}' in file '{2}'. Extent: `{1}`
-    Convert_PesterSyntax_Warning_MissingSupportedCommandOperator = Get-ShouldCommandOperatorName does not yet support support the `Should` operator that was found in file '{1}', or the operator name is short form instead of the full operator name. Extent: `{0}`
+    Convert_PesterSyntax_Warning_MissingSupportedCommandOperator = Get-ShouldCommandOperatorName does not yet support the `Should` operator that was found in file '{1}', or the operator name is short form instead of the full operator name. Extent: `{0}`
     Convert_PesterSyntax_NoPesterCommand = No supported Pester commands found in '{0}'.
     Convert_PesterSyntax_OutputPathDoesNotExist = The output path '{0}' does not exist. Please specify an existing path.
     Convert_PesterSyntax_OutputPathIsNotDirectory = The output path '{0}' is not a directory. Please specify a directory path.
     Convert_PesterSyntax_Warning_RecursivePesterCommand = Found an unsupported scenario; Pester command '{0}' is used inside another Pester command in the file '{1}'. Re-run the conversion on the converted file to convert these recursively used Pester commands.
-    Convert_PesterSyntax_Debug_RecursivePesterCommandAst = This as uses at least one recursive Pester command: {0}
+    Convert_PesterSyntax_Debug_RecursivePesterCommandAst = This AST uses at least one recursive Pester command: {0}
 
     ## Common for all Convert-Should* functions
     Convert_Should_Debug_ParsingCommandAst = Parsing the command AST: `{0}`

--- a/source/en-US/PesterConverter.strings.psd1
+++ b/source/en-US/PesterConverter.strings.psd1
@@ -28,11 +28,13 @@ ConvertFrom-StringData @'
     Convert_PesterSyntax_WriteProgress_Id2_Status_Completed = Completed.
     Convert_PesterSyntax_Debug_ScriptBlockAst = Parsing the script block AST: {0}
     Convert_PesterSyntax_Debug_FoundShouldCommand = Found {0} `Should` command(s) in file '{1}'.
-    Convert_PesterSyntax_Warning_UnsupportedCommandOperator = Unsupported command operator '{0}' in extent: `{1}`
-    Convert_PesterSyntax_MissingSupportedCommandOperator = Get-ShouldCommandOperatorName does not yet support support the Should operator that was found in extent, or the operator name is short form instead of the full operator name: `{0}`
+    Convert_PesterSyntax_Warning_UnsupportedCommandOperator = Unsupported command operator '{0}' in file '{2}'. Extent: `{1}`
+    Convert_PesterSyntax_Warning_MissingSupportedCommandOperator = Get-ShouldCommandOperatorName does not yet support support the `Should` operator that was found in file '{1}', or the operator name is short form instead of the full operator name. Extent: `{0}`
     Convert_PesterSyntax_NoPesterCommand = No supported Pester commands found in '{0}'.
     Convert_PesterSyntax_OutputPathDoesNotExist = The output path '{0}' does not exist. Please specify an existing path.
     Convert_PesterSyntax_OutputPathIsNotDirectory = The output path '{0}' is not a directory. Please specify a directory path.
+    Convert_PesterSyntax_Warning_RecursivePesterCommand = Found an unsupported scenario; Pester command '{0}' is used inside another Pester command in the file '{1}'. Re-run the conversion on the converted file to convert these recursively used Pester commands.
+    Convert_PesterSyntax_Debug_RecursivePesterCommandAst = This as uses at least one recursive Pester command: {0}
 
     ## Common for all Convert-Should* functions
     Convert_Should_Debug_ParsingCommandAst = Parsing the command AST: `{0}`

--- a/tests/Integration/Syntax/v5/ShouldInvoke.v5.tests.ps1
+++ b/tests/Integration/Syntax/v5/ShouldInvoke.v5.tests.ps1
@@ -105,4 +105,17 @@ Describe 'Should -Invoke' -Skip:$true {
             Should -Not -Invoke 'TestCommand' 1 { $Path -eq 'test.txt' }
         }
     }
+
+    It 'Should convert `Should -Invoke` even if it has another `Should` in its extent' {
+        InModuleScope -Parameters $_ -ScriptBlock {
+            1..3 | ForEach-Object { Get-Something -Path 'test.txt' }
+
+            Should -Invoke -CommandName TestCommand -ParameterFilter {
+                'a' | Should -MatchExactly 'a'
+
+                # Return $true if the assert above does not throw.
+                $true
+            } -Exactly -Times 1 -Scope It
+        }
+    }
 }

--- a/tests/Unit/Private/Convert-AssertMockCalled.tests.ps1
+++ b/tests/Unit/Private/Convert-AssertMockCalled.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBe.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBe.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeExactly.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeExactly.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeFalse.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeFalse.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeGreaterOrEqual.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeGreaterOrEqual.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeGreaterThan.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeGreaterThan.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeIn.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeIn.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeLessOrEqual.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeLessOrEqual.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeLessThan.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeLessThan.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeLike.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeLike.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeLikeExactly.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeLikeExactly.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeNullOrEmpty.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeNullOrEmpty.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeOfType.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeOfType.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldBeTrue.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldBeTrue.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldContain.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldContain.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldHaveCount.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldHaveCount.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldInvoke.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldInvoke.tests.ps1
@@ -50,6 +50,30 @@ Describe 'Convert-ShouldInvoke' {
                 }
             }
 
+            It 'Should convert a multi-line `Should -Invoke` correctly' {
+                InModuleScope -ScriptBlock {
+                    $mockCommandAst = {
+                        Should -Invoke -CommandName Start-SqlSetupProcess -ParameterFilter {
+                            $ArgumentList | Should -MatchExactly '\/quiet \/IAcceptLicenseTerms'
+
+                            # Return $true if none of the above throw.
+                            $true
+                        } -Exactly -Times 1 -Scope It
+                    }.Ast.Find({ $args[0] -is [System.Management.Automation.Language.CommandAst] }, $false)
+
+                    $result = Convert-ShouldInvoke -CommandAst $mockCommandAst -Pester6 -UseNamedParameters
+
+                    $result | Should-BeBlockString @"
+Should-Invoke -CommandName Start-SqlSetupProcess -Exactly -ParameterFilter {
+                            `$ArgumentList | Should -MatchExactly '\/quiet \/IAcceptLicenseTerms'
+
+                            # Return `$true if none of the above throw.
+                            `$true
+                        } -Scope It -Times 1
+"@
+                }
+            }
+
             It 'Should convert `Should -Invoke` using positional parameters correctly' {
                 InModuleScope -ScriptBlock {
                     $mockCommandAst = {

--- a/tests/Unit/Private/Convert-ShouldInvoke.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldInvoke.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldMatch.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldMatch.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldMatchExactly.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldMatchExactly.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldNotThrow.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldNotThrow.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Convert-ShouldThrow.tests.ps1
+++ b/tests/Unit/Private/Convert-ShouldThrow.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Get-AstDefinition.tests.ps1
+++ b/tests/Unit/Private/Get-AstDefinition.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Get-CommandAst.tests.ps1
+++ b/tests/Unit/Private/Get-CommandAst.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Get-CommandName.Tests.ps1
+++ b/tests/Unit/Private/Get-CommandName.Tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Get-PesterCommandParameter.Tests.ps1
+++ b/tests/Unit/Private/Get-PesterCommandParameter.Tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Get-PesterCommandSyntaxVersion.Tests.ps1
+++ b/tests/Unit/Private/Get-PesterCommandSyntaxVersion.Tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Get-PipelineBeforeShould.Tests.ps1
+++ b/tests/Unit/Private/Get-PipelineBeforeShould.Tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Get-ShouldCommandOperatorName.Tests.ps1
+++ b/tests/Unit/Private/Get-ShouldCommandOperatorName.Tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Test-IsPipelinePart.tests.ps1
+++ b/tests/Unit/Private/Test-IsPipelinePart.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Private/Test-PesterCommandNegated.Tests.ps1
+++ b/tests/Unit/Private/Test-PesterCommandNegated.Tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName

--- a/tests/Unit/Public/Convert-PesterSyntax.tests.ps1
+++ b/tests/Unit/Public/Convert-PesterSyntax.tests.ps1
@@ -1339,7 +1339,7 @@ Describe 'Convert-PesterSyntax' {
             It 'Should not throw an exception' {
                 $null = Convert-PesterSyntax -Path $mockScriptFilePath -PassThru
 
-                Should-Invoke -CommandName Write-Warning -Exactly -ParameterFilter { $Message -like '*Get-ShouldCommandOperatorName does not yet support support the Should operator that was found in extent*Should -BeNull*' } -Scope It -Times 1
+                Should-Invoke -CommandName Write-Warning -Exactly -ParameterFilter { $Message -like '*Get-ShouldCommandOperatorName does not yet support the Should operator that was found in extent*Should -BeNull*' } -Scope It -Times 1
             }
         }
 

--- a/tests/Unit/Public/Convert-PesterSyntax.tests.ps1
+++ b/tests/Unit/Public/Convert-PesterSyntax.tests.ps1
@@ -4,7 +4,7 @@ param ()
 BeforeAll {
     $script:dscModuleName = 'PesterConverter'
 
-    Import-Module -Name $script:dscModuleName
+    Import-Module -Name $script:dscModuleName -Force
 
     $PSDefaultParameterValues['InModuleScope:ModuleName'] = $script:dscModuleName
     $PSDefaultParameterValues['Mock:ModuleName'] = $script:dscModuleName
@@ -1338,8 +1338,8 @@ Describe 'Convert-PesterSyntax' {
 
             It 'Should not throw an exception' {
                 $null = Convert-PesterSyntax -Path $mockScriptFilePath -PassThru
-
-                Should-Invoke -CommandName Write-Warning -Exactly -ParameterFilter { $Message -like '*Get-ShouldCommandOperatorName does not yet support the Should operator that was found in extent*Should -BeNull*' } -Scope It -Times 1
+                #Get-ShouldCommandOperatorName does not yet support the `Should` operator that was found in file '/private/tmp/Pester_maij/Mock.Tests.ps1', or the operator name is short form instead of the full operator name. Extent: `Should -BeNull`
+                Should-Invoke -CommandName Write-Warning -Exactly -ParameterFilter { $Message -like '*Get-ShouldCommandOperatorName does not yet support the*Should*operator*in file*Should -BeNull*' } -Scope It -Times 1
             }
         }
 


### PR DESCRIPTION
#### Pull Request (PR) description

- Warns for an unsupported conversion scenario where a Pester command calls
  another Pester command, for example in a `FilterScript` scriptblock. If
  such edge case is found it is skipped. Another conversion pass on the
  converted file will convert those recursively used Pester commands.

#### This Pull Request (PR) fixes the following issues
- Fixes #46

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md and source/WikiSource.
- [ ] Comment-based help added/updated for all new/changed functions.
- [x] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] Integration tests added/updated (where applicable). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/PesterConverter/47)
<!-- Reviewable:end -->
